### PR TITLE
Update fork & merge change blocks to return doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ module.exports = class Hypermerge extends EventEmitter {
     return this.change(
       Automerge.merge(doc, parent),
       `Forked from ${parentId}`,
-      () => {})
+      (doc) => { return doc })
   }
 
   /**
@@ -181,7 +181,7 @@ module.exports = class Hypermerge extends EventEmitter {
     return this.change(
       Automerge.merge(dest, source),
       `Merged with ${sourceId}`,
-      () => {})
+      (doc) => { return doc })
   }
 
   /**


### PR DESCRIPTION
These returns are required by the WIP immutable-write-interface branch of
Automerge, to be able to fork and merge docs via Hypermerge.

The mutable branch of Automerge ignores the return value of the change
block, so this should be fine for existing apps.