### PR TITLE
Updated hypercore-crypto import

### DIFF
--- a/MultiCore.js
+++ b/MultiCore.js
@@ -2,7 +2,7 @@ const {EventEmitter} = require('events')
 const protocol = require('hypercore-protocol')
 const Archiver = require('hypercore-archiver')
 const hypercore = require('hypercore')
-const crypto = require('hypercore/lib/crypto')
+const crypto = require('hypercore-crypto')
 const thunky = require('thunky')
 const toBuffer = require('to-buffer')
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "automerge": "^0.7.0",
     "hypercore": "^6.12.0",
+    "hypercore-crypto": "^1.0.0",
     "hypercore-archiver": "^4.4.1",
     "hypercore-protocol": "^6.5.1",
     "thunky": "^1.0.2",


### PR DESCRIPTION
It looks like hypercore's crypto functionality was moved and so the import needed to be updated.