### PR TITLE
WIP: Untangle hypermerge from hypercore

### DIFF
--- a/src/DocBackend.ts
+++ b/src/DocBackend.ts
@@ -3,9 +3,8 @@ import * as Backend from "automerge/backend"
 import { Change, BackDoc } from "automerge/backend"
 import { ToBackendRepoMsg, ToFrontendRepoMsg } from "./RepoMsg"
 import Queue from "./Queue"
-import { EXT, RepoBackend } from "./RepoBackend"
+import { RepoBackend } from "./RepoBackend"
 import { Feed, Peer } from "./hypercore"
-
 
 const log = Debug("hypermerge:back")
 
@@ -27,7 +26,11 @@ export class DocBackend {
       this.actorId = docId
       this.subscribeToRemoteChanges()
       this.subscribeToLocalChanges()
-      this.repo.toFrontend.push({ type: "ReadyMsg", id: this.docId, actorId: docId })
+      this.repo.toFrontend.push({
+        type: "ReadyMsg",
+        id: this.docId,
+        actorId: docId
+      })
     }
   }
 
@@ -54,7 +57,11 @@ export class DocBackend {
       if (!this.actorId) {
         this.actorId = this.repo.initActorFeed(this)
       }
-      this.repo.toFrontend.push({ type: "ActorIdMsg", id: this.docId, actorId: this.actorId})
+      this.repo.toFrontend.push({
+        type: "ActorIdMsg",
+        id: this.docId,
+        actorId: this.actorId
+      })
     } else {
       // remember we want one for when init happens
       this.wantsActor = true
@@ -71,7 +78,12 @@ export class DocBackend {
       this.back = back
       this.subscribeToLocalChanges()
       this.subscribeToRemoteChanges()
-      this.repo.toFrontend.push({ type: "ReadyMsg", id: this.docId, actorId: this.actorId, patch})
+      this.repo.toFrontend.push({
+        type: "ReadyMsg",
+        id: this.docId,
+        actorId: this.actorId,
+        patch
+      })
     })
   }
 
@@ -109,7 +121,7 @@ export class DocBackend {
   }
 
   message(peer: Peer, message: any) {
-    peer.stream.extension(EXT, Buffer.from(JSON.stringify(message)))
+    peer.send(Buffer.from(JSON.stringify(message)))
   }
 
   messageMetadata(peer: Peer) {

--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -1,4 +1,3 @@
-
 import { Options, RepoBackend } from "./RepoBackend"
 import { RepoFrontend } from "./RepoFrontend"
 import Handle from "./Handle"
@@ -13,8 +12,7 @@ export class Repo {
   front: RepoFrontend
   back: RepoBackend
   id: Buffer
-  stream: (opts: any) => any
-
+  // stream: (opts: any) => any
 
   constructor(opts: Options) {
     this.front = new RepoFrontend()
@@ -22,14 +20,14 @@ export class Repo {
     this.front.subscribe(this.back.receive)
     this.back.subscribe(this.front.receive)
     this.id = this.back.id
-    this.stream = this.back.stream
+    // this.stream = this.back.stream
   }
 
-  create() : string {
+  create(): string {
     return this.front.create()
   }
 
-  open<T>(id: string) : Handle<T> {
+  open<T>(id: string): Handle<T> {
     return this.front.open(id)
   }
 

--- a/src/RepoBackend.ts
+++ b/src/RepoBackend.ts
@@ -1,17 +1,20 @@
-
 import Queue from "./Queue"
 import MapSet from "./MapSet"
 import * as JsonBuffer from "./JsonBuffer"
 import * as Base58 from "bs58"
-import * as crypto from "hypercore/lib/crypto"
-import { hypercore, Feed, Peer, discoveryKey } from "./hypercore"
+import {
+  hypercore,
+  Feed,
+  Peer,
+  discoveryKey,
+  keyPair,
+  KeyBuffer
+} from "./hypercore"
 import * as Backend from "automerge/backend"
 import { Change } from "automerge/backend"
 import { ToBackendRepoMsg, ToFrontendRepoMsg } from "./RepoMsg"
 import { DocBackend } from "./DocBackend"
 import Debug from "debug"
-
-export const EXT = "hypermerge"
 
 type FeedFn = (f: Feed<Uint8Array>) => void
 
@@ -26,11 +29,6 @@ Debug.formatters.b = Base58.encode
 const HypercoreProtocol: Function = require("hypercore-protocol")
 
 const log = Debug("repo:backend")
-
-export interface KeyBuffer {
-  publicKey: Buffer
-  secretKey?: Buffer
-}
 
 export interface FeedData {
   actorId: string
@@ -51,7 +49,7 @@ export interface LedgerData {
 export class RepoBackend {
   path?: string
   storage: Function
-  ready: Promise<undefined>
+  ready: Promise<void>
   joined: Set<Buffer> = new Set()
   feeds: Map<string, Feed<Uint8Array>> = new Map()
   feedQs: Map<string, Queue<FeedFn>> = new Map()
@@ -72,22 +70,24 @@ export class RepoBackend {
     this.storage = opts.storage
     this.ledger = hypercore(this.storageFn("ledger"), { valueEncoding: "json" })
     this.id = this.ledger.id
-    this.ready = new Promise((resolve, reject) => {
-      this.ledger.ready(() => {
-        log("Ledger ready: size", this.ledger.length)
-        if (this.ledger.length > 0) {
-          this.ledger.getBatch(0, this.ledger.length, (err, data) => {
-            data.forEach(d => {
-              this.docMetadata.merge(d.docId, d.actorIds)
-              this.ledgerMetadata.merge(d.docId, d.actorIds)
-            })
-            resolve()
-          })
-        } else {
-          resolve()
-        }
-      })
-    })
+    this.ready = this.init()
+  }
+
+  async init() {
+    await this.ledger.ready
+    log("Ledger ready: size", this.ledger.length)
+    if (this.ledger.length > 0) {
+      const data = await this.ledger.slice(0)
+
+      for (const { docId, actorIds } of data) {
+        this.mergeMetadata(docId, actorIds)
+      }
+    }
+  }
+
+  mergeMetadata(docId: string, actorIds: string[]) {
+    this.docMetadata.merge(docId, actorIds)
+    this.ledgerMetadata.merge(docId, actorIds)
   }
 
   private createDocBackend(keys: KeyBuffer): DocBackend {
@@ -133,45 +133,36 @@ export class RepoBackend {
     }
   }
 
-  private feedData(doc: DocBackend, actorId: string): Promise<FeedData> {
-    return new Promise((resolve, reject) => {
-      this.getFeed(doc, actorId, feed => {
-        const writable = feed.writable
-        if (feed.length > 0) {
-          feed.getBatch(0, feed.length, (err, datas) => {
-            const changes = datas.map(JsonBuffer.parse)
+  private async feedData(doc: DocBackend, actorId: string): Promise<FeedData> {
+    const feed = await this.getFeed(doc, actorId)
+    const writable = feed.writable
+    if (feed.length > 0) {
+      const datas = await feed.slice(0, feed.length)
+      const changes = datas.map(JsonBuffer.parse)
 
-            if (err) {
-              reject(err)
-            }
+      this.feedSeq.set(actorId, datas.length)
 
-            this.feedSeq.set(actorId, datas.length)
-
-            resolve({ actorId, writable, changes })
-          })
-        } else {
-          resolve({ actorId, writable, changes: [] })
-        }
-      })
-    })
+      return { actorId, writable, changes }
+    } else {
+      return { actorId, writable, changes: [] }
+    }
   }
 
   private allFeedData(doc: DocBackend): Promise<FeedData[]> {
     return Promise.all(doc.actorIds().map(key => this.feedData(doc, key)))
   }
 
-  writeChange(doc: DocBackend, actorId: string, change: Change) {
+  async writeChange(doc: DocBackend, actorId: string, change: Change) {
     const feedLength = this.feedSeq.get(actorId) || 0
     const ok = feedLength + 1 === change.seq
     log(`write actor=${actorId} seq=${change.seq} feed=${feedLength} ok=${ok}`)
     this.feedSeq.set(actorId, feedLength + 1)
-    this.getFeed(doc, actorId, feed => {
-      feed.append(JsonBuffer.bufferify(change), err => {
-        if (err) {
-          throw new Error("failed to append to feed")
-        }
-      })
-    })
+    const feed = await this.getFeed(doc, actorId)
+    try {
+      await feed.append(JsonBuffer.bufferify(change))
+    } catch (error) {
+      throw new Error("failed to append to feed")
+    }
   }
 
   private loadDocument(doc: DocBackend) {
@@ -183,7 +174,7 @@ export class RepoBackend {
           .shift()
         const changes = ([] as Change[]).concat(...feedData.map(f => f.changes))
         doc.init(changes, writer)
-      }),
+      })
     )
   }
 
@@ -203,12 +194,17 @@ export class RepoBackend {
     this.joined.delete(dk)
   }
 
-  private getFeed = (doc: DocBackend, actorId: string, cb: FeedFn) => {
-    const publicKey = Base58.decode(actorId)
-    const dk = discoveryKey(publicKey)
-    const dkString = Base58.encode(dk)
-    const q = this.feedQs.get(dkString) || this.initFeed(doc, { publicKey })
-    q.push(cb)
+  private async getFeed(
+    doc: DocBackend,
+    actorId: string
+  ): Promise<Feed<Uint8Array>> {
+    return new Promise((resolve, reject) => {
+      const publicKey = Base58.decode(actorId)
+      const dk = discoveryKey(publicKey)
+      const dkString = Base58.encode(dk)
+      const q = this.feedQs.get(dkString) || this.initFeed(doc, { publicKey })
+      q.push(resolve)
+    })
   }
 
   private storageFn(path: string): Function {
@@ -219,18 +215,14 @@ export class RepoBackend {
 
   initActorFeed(doc: DocBackend): string {
     log("initActorFeed", doc.docId)
-    const keys = crypto.keyPair()
+    const keys = keyPair()
     const actorId = Base58.encode(keys.publicKey)
     this.initFeed(doc, keys)
     return actorId
   }
 
-  sendToPeer(peer: Peer, data: any) {
-    peer.stream.extension(EXT, Buffer.from(JSON.stringify(data)))
-  }
-
   actorIds(doc: DocBackend): string[] {
-    return [... this.docMetadata.get(doc.docId)]
+    return [...this.docMetadata.get(doc.docId)]
   }
 
   feed(actorId: string): Feed<Uint8Array> {
@@ -243,8 +235,8 @@ export class RepoBackend {
   peers(doc: DocBackend): Peer[] {
     return ([] as Peer[]).concat(
       ...this.actorIds(doc).map(actorId => [
-        ...(this.feedPeers.get(actorId) || []),
-      ]),
+        ...(this.feedPeers.get(actorId) || [])
+      ])
     )
   }
 
@@ -259,7 +251,7 @@ export class RepoBackend {
     const dk = discoveryKey(publicKey)
     const dkString = Base58.encode(dk)
     const feed: Feed<Uint8Array> = hypercore(storage, publicKey, {
-      secretKey,
+      secretKey
     })
     const q = new Queue<FeedFn>()
     const peers = new Set()
@@ -268,76 +260,68 @@ export class RepoBackend {
     this.feedPeers.set(actorId, peers)
     this.addMetadata(doc.docId, actorId)
     log("init feed", actorId)
-    feed.ready(() => {
+
+    const init = async () => {
+      await feed.ready
       this.feedSeq.set(actorId, 0)
       doc.broadcastMetadata()
       this.join(actorId)
-      feed.on("peer-remove", (peer: Peer) => {
-        peers.delete(peer)
-      })
-      feed.on("peer-add", (peer: Peer) => {
-        peer.stream.on("extension", (ext: string, buf: Buffer) => {
-          if (ext === EXT) {
-            const msg: string[] = JSON.parse(buf.toString())
-            log("EXT", msg)
-            // getFeed -> initFeed -> join()
-            msg.forEach(actorId => this.getFeed(doc, actorId, _ => { }))
-          }
-        })
+      feed.ondata = (changes: any) => doc.applyRemoteChanges(changes)
+      feed.onpeer = peer => {
         peers.add(peer)
         doc.messageMetadata(peer)
-      })
 
-      let remoteChanges: Change[] = []
-      feed.on("download", (idx, data) => {
-        remoteChanges.push(JsonBuffer.parse(data))
-      })
-      feed.on("sync", () => {
-        doc.applyRemoteChanges(remoteChanges)
-        remoteChanges = []
-      })
+        peer.onclose = () => peers.delete(peer)
+        peer.onmessage = (data: Buffer) => {
+          const msg: string[] = JSON.parse(data.toString())
+          log("EXT", msg)
+          // getFeed -> initFeed -> join()
+          msg.forEach(actorId => void this.getFeed(doc, actorId))
+        }
+      }
 
       this.feedQs.get(dkString)!.subscribe(f => f(feed))
 
-      feed.on("close", () => {
-        log("closing feed", actorId)
-        this.feeds.delete(dkString)
-        this.feedQs.delete(dkString)
-        this.feedPeers.delete(actorId)
-        this.feedSeq.delete(actorId)
-      })
-    })
+      await feed.closed
+      log("closing feed", actorId)
+      this.feeds.delete(dkString)
+      this.feedQs.delete(dkString)
+      this.feedPeers.delete(actorId)
+      this.feedSeq.delete(actorId)
+    }
+
+    init()
+
     return q
   }
 
-  stream = (opts: any): any => {
-    const stream = HypercoreProtocol({
-      live: true,
-      id: this.ledger.id,
-      encrypt: false,
-      timeout: 10000,
-      extensions: [EXT],
-    })
+  // stream = (opts: any): any => {
+  //   const stream = HypercoreProtocol({
+  //     live: true,
+  //     id: this.ledger.id,
+  //     encrypt: false,
+  //     timeout: 10000,
+  //     extensions: [EXT]
+  //   })
 
-    let add = (dk: Buffer) => {
-      const feed = this.feeds.get(Base58.encode(dk))
-      if (feed) {
-        log("replicate feed!", Base58.encode(dk))
-        feed.replicate({
-          stream,
-          live: true,
-        })
-      }
-    }
+  //   let add = (dk: Buffer) => {
+  //     const feed = this.feeds.get(Base58.encode(dk))
+  //     if (feed) {
+  //       log("replicate feed!", Base58.encode(dk))
+  //       feed.replicate({
+  //         stream,
+  //         live: true
+  //       })
+  //     }
+  //   }
 
+  //   stream.on("feed", (dk: Buffer) => add(dk))
 
-    stream.on("feed", (dk: Buffer) => add(dk))
+  //   const dk = opts.channel || opts.discoveryKey
+  //   if (dk) add(dk)
 
-    const dk = opts.channel || opts.discoveryKey
-    if (dk) add(dk)
-
-    return stream
-  }
+  //   return stream
+  // }
 
   releaseManager(doc: DocBackend) {
     const actorIds = doc.actorIds()
@@ -368,13 +352,12 @@ export class RepoBackend {
           secretKey: Base58.decode(msg.secretKey)
         }
         this.createDocBackend(keys)
-        break;
+        break
       }
       case "OpenMsg": {
         this.openDocBackend(msg.id)
         break
       }
-
     }
     //export type ToBackendMsg = NeedsActorIdMsg | RequestMsg | CreateMsg | OpenMsg
   }

--- a/src/RepoFrontend.ts
+++ b/src/RepoFrontend.ts
@@ -1,10 +1,9 @@
-
 import Queue from "./Queue"
 import * as Base58 from "bs58"
-import * as crypto from "hypercore/lib/crypto"
 import { ToBackendRepoMsg, ToFrontendRepoMsg } from "./RepoMsg"
 import Handle from "./Handle"
 import { DocFrontend } from "./DocFrontend"
+import { keyPair } from "./hypercore"
 import Debug from "debug"
 
 Debug.formatters.b = Base58.encode
@@ -16,7 +15,7 @@ export class RepoFrontend {
   docs: Map<string, DocFrontend<any>> = new Map()
 
   create(): string {
-    const keys = crypto.keyPair()
+    const keys = keyPair()
     const publicKey = Base58.encode(keys.publicKey)
     const secretKey = Base58.encode(keys.secretKey)
     const docId = publicKey

--- a/src/hypercore.ts
+++ b/src/hypercore.ts
@@ -1,6 +1,9 @@
 declare function require(moduleName: string): any
 
+import * as JsonBuffer from "./JsonBuffer"
 let _hypercore = require("hypercore")
+let _crypto = require("hypercore/lib/crypto")
+const EXT = "hypermerge"
 
 type Key = string | Buffer
 type Storage = string | Function
@@ -18,7 +21,7 @@ export function hypercore<T>(storage: Storage, options: Options): Feed<T>
 export function hypercore<T>(
   storage: Storage,
   key: Key,
-  options: Options,
+  options: Options
 ): Feed<T>
 export function hypercore<T>(storage: Storage, arg2: any, arg3?: any): Feed<T> {
   if (arg3) {
@@ -28,7 +31,7 @@ export function hypercore<T>(storage: Storage, arg2: any, arg3?: any): Feed<T> {
   }
 }
 
-export interface Feed<T> {
+export interface HypercoreFeed<T> {
   on(event: "ready", cb: () => void): this
   on(event: "close", cb: () => void): this
   on(event: "sync", cb: () => void): this
@@ -36,8 +39,8 @@ export interface Feed<T> {
   on(event: "download", cb: (index: number, data: Buffer) => void): this
   on(event: "upload", cb: (index: number, data: T) => void): this
   on(event: "data", cb: (idx: number, data: T) => void): this
-  on(event: "peer-add", cb: (peer: Peer) => void): this
-  on(event: "peer-remove", cb: (peer: Peer) => void): this
+  on(event: "peer-add", cb: (peer: HypercorePeer) => void): this
+  on(event: "peer-remove", cb: (peer: HypercorePeer) => void): this
   on(event: "extension", cb: (a: any, b: any) => void): this
 
   peers: Peer[]
@@ -46,7 +49,7 @@ export interface Feed<T> {
   ready: Function
   append(data: T): void
   append(data: T, cb: (err: Error | null) => void): void
-  close() : void
+  close(): void
   get(index: number, cb: (data: T) => void): void
   getBatch(start: number, end: number, cb: (Err: any, data: T[]) => void): void
   discoveryKey: Buffer
@@ -54,8 +57,142 @@ export interface Feed<T> {
   length: number
 }
 
-export interface Peer {
+interface HypercorePeer {
   feed: any
   stream: any
-  onextension: any
+
+  $hypemerge$onmessage: void | ((data: Buffer) => void)
+  $hypemerge$onclose: void | (() => void)
+}
+
+export interface KeyBuffer {
+  publicKey: Buffer
+  secretKey?: Buffer
+}
+
+export interface KeyPair {
+  publicKey: Buffer
+  secretKey: Buffer
+}
+
+export function keyPair(): KeyPair {
+  return _crypto.keyPair()
+}
+
+export interface Peer {
+  send(data: Buffer): void
+  onclose: void | (() => void)
+  onmessage: void | ((data: Buffer) => void)
+}
+
+export interface Feed<T> {
+  id: Buffer
+  ready: Promise<void>
+  writable: Boolean
+  closed: Promise<void>
+  length: number
+  ondata?: (chunks: T[]) => void
+  onpeer?: (peer: Peer) => void
+
+  append(data: T): Promise<void>
+  slice(start: number): Promise<T[]>
+  slice(start: number, end: number): Promise<T[]>
+  close(): void
+}
+
+class HyperPeer implements Peer {
+  core: HypercorePeer
+  constructor(core: HypercorePeer) {
+    this.core = core
+  }
+  set onmessage(onmessage: void | ((message: Buffer) => void)) {
+    this.core.$hypemerge$onmessage = onmessage
+  }
+  get onmessage() {
+    return this.core.$hypemerge$onmessage
+  }
+  set onclose(onclose: void | (() => void)) {
+    this.core.$hypemerge$onclose = onclose
+  }
+  get onclose() {
+    return this.core.$hypemerge$onclose
+  }
+  send(data: Buffer): void {
+    this.core.stream.extension(EXT, data)
+  }
+}
+
+export class HyperFeed<T> implements Feed<T> {
+  core: HypercoreFeed<T>
+  id: Buffer
+  ready: Promise<void>
+  closed: Promise<void>
+  ondata?: (chunks: T[]) => void
+  onpeer?: (peer: Peer) => void
+  dataQ: T[]
+  constructor(core: HypercoreFeed<T>) {
+    this.core = core
+    this.id = core.id
+    this.ready = new Promise(resolve => core.on("ready", resolve))
+    this.closed = new Promise(resolve => core.on("close", resolve))
+    this.dataQ = []
+    core.on("download", (idx, data) => {
+      this.dataQ.push(JsonBuffer.parse(data))
+    })
+    core.on("sync", () => {
+      if (this.ondata) {
+        this.ondata(this.dataQ.splice(0))
+      }
+    })
+
+    core.on("peer-add", (core: HypercorePeer) => {
+      core.stream.on("extension", (ext: string, buffer: Buffer) => {
+        if (ext === EXT && core.$hypemerge$onmessage) {
+          core.$hypemerge$onmessage(buffer)
+        }
+      })
+
+      const peer = new HyperPeer(core)
+      if (this.onpeer) {
+        this.onpeer(peer)
+      }
+    })
+
+    core.on("peer-remove", (peer: HypercorePeer) => {
+      if (peer.$hypemerge$onclose) {
+        peer.$hypemerge$onclose()
+      }
+    })
+  }
+  get length() {
+    return this.core.length
+  }
+  get writable() {
+    return this.core.writable
+  }
+  append(data: T): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.core.append(data, error => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+  slice(start: number, end: number = this.length): Promise<T[]> {
+    return new Promise((resolve, reject) => {
+      this.core.getBatch(start, end, (error, data) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+  close(): void {
+    this.core.close()
+  }
 }


### PR DESCRIPTION
I would like to untangle hypermerge from the hypercore so that alternative feed / replication mechanism could be provided (I'm specifically looking into IPFS base one). While it's certainly possible to just copy & paste and replace relevant bits, I think there is plenty of code that is hypercore agnostic and it might be useful to try and refactor relevant bits to facilitate better reuse / simplify implementation of alternative protocol providers.

This is my best attempt to do so & in it's current state I could use some feedback. Below are some highlights:

- Moved `hypercore/lib/crypto` dependency into `hypercore` module to expose `keyPair` function instead. IMO it also should be made as async as corresponding browser native APIs is async and so is the API exposed by IPFS. It also probably would make sense to make `keyPair` an option passed to `Repo` and things it delegates to.
- `Feed` interface from hypercore is very fat and opinionated, furthermore all uses of it tend to wrap around with promises. I renamed former `Feed` to `HypercoreFeed` and defined new `Feed` with a thinner promise based API to reflect only things that are actually used by hypermerge.
- `Peer` interface from hypercore is also complex exposing internal `.stream` that from what I can tell is only used for sending a message (feed id) to the corresponding peer. There for I defined new `Peer` interface that just exposes `send`, `onmessage` and `onclose`. It would be a lot easier to comply with this API than the original. Also `ondata` takes care of buffering that originally was done via `download` + `sync` coordinated events.
- `Repo().stream` seems awkward, I get it's used for replication with a swarm, but still assumes a lot of implementation details. One option wolud be to change that to move `stream` function to the `hypercore.ts` instead but that does not seem ideal. I think it would be better to move it into `Feed` somehow, however I'm not exactly sure how yet. Since it used across libs it is a lot more difficult for me to see all the edges.

I am also little unsure on

- why does feed IDs are communicated the way they are. Or put it differently why is it not just a special  message in the feed ? Only reason I can think of is to replicate with higher priority, but actual insight would be help.

### P.S.: I apologize for formatting changes, just noticed those & I presume they're caused by [prettier](http://prettier.io/) plugin. 