### PR TITLE
Use consistent naming for Queues

### DIFF
--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -106,7 +106,7 @@ export class Actor {
     this.notify = config.notify
     this.dkString = Base58.encode(dk)
     this.feed = hypercore(this.storage, publicKey, { secretKey })
-    this.q = new Queue<(actor: Actor) => void>("actor:q-" + id.slice(0, 4))
+    this.q = new Queue<(actor: Actor) => void>("repo:actor:Q" + id.slice(0, 4))
     this.feed.ready(this.onFeedReady)
   }
 

--- a/src/DocBackend.ts
+++ b/src/DocBackend.ts
@@ -62,12 +62,12 @@ export class DocBackend {
   clock: Clock = {};
   back?: BackDoc; // can we make this private?
   changes: Map<string, number> = new Map()
-  ready = new Queue<Function>("backend:ready");
+  ready = new Queue<Function>("doc:back:readyQ");
   private notify: (msg: DocBackendMessage) => void
   private remoteClock?: Clock = undefined;
   private synced : boolean = false
-  private localChangeQ = new Queue<Change>("backend:localChangeQ");
-  private remoteChangesQ = new Queue<Change[]>("backend:remoteChangesQ");
+  private localChangeQ = new Queue<Change>("doc:back:localChangeQ");
+  private remoteChangesQ = new Queue<Change[]>("doc:back:remoteChangesQ");
 
   constructor(documentId: string, notify: (msg: DocBackendMessage) => void, back?: BackDoc) {
     this.id = documentId;

--- a/src/DocFrontend.ts
+++ b/src/DocFrontend.ts
@@ -26,7 +26,7 @@ export class DocFrontend<T> {
   actorId?: string;
   history: number = 0;
   //  private toBackend: Queue<ToBackendRepoMsg>
-  private changeQ = new Queue<ChangeFn<T>>("frontend:change");
+  private changeQ = new Queue<ChangeFn<T>>("repo:front:changeQ");
   private front: Doc<T>;
   private mode: Mode = "pending";
   private handles: Set<Handle<T>> = new Set();

--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -190,7 +190,7 @@ export class Metadata {
   private files: Map<string, number> = new Map();
   private mimeTypes: Map<string, string> = new Map();
   private merges: Map<string, Clock> = new Map();
-  readyQ: Queue<() => void> = new Queue(); // FIXME - need a better api for accessing metadata
+  readyQ: Queue<() => void> = new Queue("repo:metadata:readyQ"); // FIXME - need a better api for accessing metadata
   private _clocks: { [id:string]: Clock } = {}
   private _docsWith: Map<string, string[]> = new Map()
 

--- a/src/RepoBackend.ts
+++ b/src/RepoBackend.ts
@@ -46,7 +46,7 @@ export class RepoBackend {
   docs: Map<string, DocBackend.DocBackend> = new Map();
   meta: Metadata;
   opts: Options;
-  toFrontend: Queue<ToFrontendRepoMsg> = new Queue("repo:toFrontend");
+  toFrontend: Queue<ToFrontendRepoMsg> = new Queue("repo:back:toFrontend");
   swarm?: Swarm;
   id: Buffer;
   file?: Uint8Array;

--- a/src/RepoFrontend.ts
+++ b/src/RepoFrontend.ts
@@ -32,7 +32,7 @@ export interface ProgressEvent {
 let msgid = 1
 
 export class RepoFrontend {
-  toBackend: Queue<ToBackendRepoMsg> = new Queue("repo:tobackend");
+  toBackend: Queue<ToBackendRepoMsg> = new Queue("repo:front:toBackendQ");
   docs: Map<string, DocFrontend<any>> = new Map();
   cb: Map<number, (reply: any) => void> = new Map();
   msgcb: Map<number, (patch: Patch) => void> = new Map();


### PR DESCRIPTION
Helpful for debugging with `DEBUG=queue:*`