### PR TITLE
Use opaque types for document ids and actor ids

### DIFF
--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -4,7 +4,7 @@
  */
 import { readFeed, hypercore, Feed, Peer, discoveryKey } from "./hypercore"
 import { Change } from "automerge/backend"
-import { ID } from "./Misc"
+import { ID, ActorId, DiscoveryId, encodeActorId, encodeDiscoveryId } from "./Misc"
 import Queue from "./Queue"
 import * as JsonBuffer from "./JsonBuffer"
 import * as Base58 from "bs58"
@@ -82,8 +82,8 @@ interface ActorConfig {
 }
 
 export class Actor {
-  id: string
-  dkString: string
+  id: ActorId
+  dkString: DiscoveryId
   changes: Change[] = []
   feed: Feed<Uint8Array>
   peers: Map<string, Peer> = new Map()
@@ -98,13 +98,13 @@ export class Actor {
   constructor(config: ActorConfig) {
     const { publicKey, secretKey } = config.keys
     const dk = discoveryKey(publicKey)
-    const id = Base58.encode(publicKey)
+    const id = encodeActorId(publicKey)
 
     this.type = "Unknown"
     this.id = id
     this.storage = config.storage(id)
     this.notify = config.notify
-    this.dkString = Base58.encode(dk)
+    this.dkString = encodeDiscoveryId(dk)
     this.feed = hypercore(this.storage, publicKey, { secretKey })
     this.q = new Queue<(actor: Actor) => void>("repo:actor:Q" + id.slice(0, 4))
     this.feed.ready(this.onFeedReady)

--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -1,5 +1,7 @@
+import { ActorId } from "./Misc";
+
 export interface Clock {
-  [actorId: string]: number;
+  [actorId: string /* ActorId */]: number;
 }
 
 export type CMP = "GT" | "LT" | "CONCUR" | "EQ"
@@ -27,6 +29,10 @@ export function cmp(a: Clock, b: Clock) : CMP {
     return "LT"
   }
   return "CONCUR"
+}
+
+export function clockActorIds(clock: Clock): ActorId[] {
+  return Object.keys(clock) as ActorId[]
 }
 
 export function strs2clock(input: string | string[]): Clock {

--- a/src/DocFrontend.ts
+++ b/src/DocFrontend.ts
@@ -5,6 +5,7 @@ import { Clock, union } from "./Clock";
 import Queue from "./Queue";
 import { Handle } from "./Handle";
 import Debug from "debug";
+import { ActorId, DocId, DocUrl, asDocUrl } from "./Misc";
 
 // TODO - i bet this can be rewritten where the Frontend allocates the actorid on write - this
 // would make first writes a few ms faster
@@ -16,14 +17,15 @@ export type Patch = Patch;
 type Mode = "pending" | "read" | "write";
 
 interface Config {
-  docId: string;
-  actorId?: string;
+  docId: DocId;
+  actorId?: ActorId;
 }
 
 export class DocFrontend<T> {
-  private docId: string;
+  private docId: DocId;
+  private docUrl: DocUrl;
   ready: boolean = false; // do I need ready? -- covered my state !== pending?
-  actorId?: string;
+  actorId?: ActorId;
   history: number = 0;
   //  private toBackend: Queue<ToBackendRepoMsg>
   private changeQ = new Queue<ChangeFn<T>>("repo:front:changeQ");
@@ -41,23 +43,24 @@ export class DocFrontend<T> {
     const actorId = config.actorId;
     this.repo = repo;
     this.clock = {};
+    this.docId = docId;
+    this.docUrl = asDocUrl(docId)
+
     //    this.toBackend = toBackend
 
     if (actorId) {
       this.front = Frontend.init(actorId) as Doc<T>;
-      this.docId = docId;
       this.actorId = actorId;
       this.ready = true
       this.mode = "write";
       this.enableWrites();
     } else {
       this.front = Frontend.init({ deferActorId: true }) as Doc<T>;
-      this.docId = docId;
     }
   }
 
   handle(): Handle<T> {
-    let handle = new Handle<T>(this.repo, this.docId);
+    let handle = new Handle<T>(this.repo, this.docUrl);
     this.handles.add(handle);
     handle.cleanup = () => this.handles.delete(handle);
     handle.changeFn = this.change;
@@ -105,7 +108,7 @@ export class DocFrontend<T> {
     // what does this do now? - FIXME
   };
 
-  setActorId = (actorId: string) => {
+  setActorId = (actorId: ActorId) => {
     log("setActorId", this.docId, actorId, this.mode);
     this.actorId = actorId;
     this.front = Frontend.setActorId(this.front, actorId);
@@ -116,7 +119,7 @@ export class DocFrontend<T> {
     }
   };
 
-  init = (synced: boolean, actorId?: string, patch?: Patch, history?: number) => {
+  init = (synced: boolean, actorId?: ActorId, patch?: Patch, history?: number) => {
     log(
       `init docid=${this.docId} actorId=${actorId} patch=${!!patch} history=${history} mode=${
         this.mode

--- a/src/DocFrontend.ts
+++ b/src/DocFrontend.ts
@@ -5,7 +5,7 @@ import { Clock, union } from "./Clock";
 import Queue from "./Queue";
 import { Handle } from "./Handle";
 import Debug from "debug";
-import { ActorId, DocId, DocUrl, asDocUrl } from "./Misc";
+import { ActorId, DocId, DocUrl, toDocUrl } from "./Misc";
 
 // TODO - i bet this can be rewritten where the Frontend allocates the actorid on write - this
 // would make first writes a few ms faster
@@ -44,7 +44,7 @@ export class DocFrontend<T> {
     this.repo = repo;
     this.clock = {};
     this.docId = docId;
-    this.docUrl = asDocUrl(docId)
+    this.docUrl = toDocUrl(docId)
 
     //    this.toBackend = toBackend
 

--- a/src/DocumentBroadcast.ts
+++ b/src/DocumentBroadcast.ts
@@ -1,18 +1,19 @@
 /**
  * Communicate document information required to replicate documents and their actors.
- * 
+ *
  * TODO: Rename. Discover? Advertise?
- * 
+ *
  * TODO: Clean up dependency on Metadata. The extension should know its own format and
  * translate that to something metadata can use.
- * 
+ *
  * TODO: Move more of the logic for which peers to send messages to into this module. Will require
  * a data structure representing the actor/peers/document relationships which this module can operate on.
  */
 import * as Metadata from "./Metadata"
-import { DocumentMsg } from "./RepoMsg" 
+import { DocumentMsg } from "./RepoMsg"
 import * as Clock from "./Clock"
 import { Peer } from "./hypercore"
+import { DocId } from "./Misc";
 
 
 export const EXTENSION_V2 = "hypermerge.2"
@@ -39,14 +40,14 @@ export function broadcast(message: BroadcastMessage, peers: Iterable<Peer>) {
 
 export function broadcastMetadata(
     blocks: Metadata.MetadataBlock[],
-    clocks: { [id: string]: Clock.Clock },
+    clocks: { [id: string /* ActorId */]: Clock.Clock },
     peers: Iterable<Peer>
   ) {
     const message: Metadata.RemoteMetadata = { type: "RemoteMetadata", clocks, blocks }
     broadcast(message, peers)
 }
 
-export function broadcastDocumentMessage(id: string, contents: any, peers: Iterable<Peer>) {
+export function broadcastDocumentMessage(id: DocId, contents: any, peers: Iterable<Peer>) {
     const message: DocumentMsg = { type: "DocumentMessage", id, contents }
     broadcast(message, peers)
 }
@@ -75,7 +76,7 @@ function parseMessage(extension: string, input: Uint8Array) {
                     break
                 }
                 case "DocumentMessage": {
-                    // no need to edit the message, we can just pass it through 
+                    // no need to edit the message, we can just pass it through
                     break
                 }
                 default: {

--- a/src/Handle.ts
+++ b/src/Handle.ts
@@ -1,8 +1,10 @@
 import { Clock, Doc, ChangeFn } from "automerge/frontend";
 import { RepoFrontend, ProgressEvent } from "./RepoFrontend";
+import { DocUrl } from "./Misc";
 
 export class Handle<T> {
-  id: string = "";
+  // id: DocId
+  url: DocUrl;
   state: Doc<T> | null = null;
   clock: Clock | null = null;
   subscription?: (item: Doc<T>, clock?: Clock, index?: number) => void;
@@ -11,13 +13,13 @@ export class Handle<T> {
   private counter: number = 0;
   private repo: RepoFrontend;
 
-  constructor(repo: RepoFrontend, id: string) {
+  constructor(repo: RepoFrontend, url: DocUrl) {
     this.repo = repo;
-    this.id = id;
+    this.url = url;
   }
 
-  fork(): string {
-    return this.repo.fork(this.id);
+  fork(): DocUrl {
+    return this.repo.fork(this.url);
   }
 
 /*
@@ -29,12 +31,12 @@ export class Handle<T> {
 */
 
   merge(other: Handle<T>): this {
-    this.repo.merge(this.id, other.id);
+    this.repo.merge(this.url, other.url);
     return this;
   }
 
   message = ( contents: any): this => {
-    this.repo.message(this.id, contents)
+    this.repo.message(this.url, contents)
     return this
   }
 
@@ -89,9 +91,9 @@ export class Handle<T> {
     if (this.progressSubscription) {
       throw new Error("only one progress subscriber for a doc handle")
     }
-    
+
     this.progressSubscription = subscriber
-  
+
     return this
   }
 
@@ -101,9 +103,9 @@ export class Handle<T> {
     if (this.messageSubscription) {
       throw new Error("only one document message subscriber for a doc handle")
     }
-    
+
     this.messageSubscription = subscriber
-  
+
     return this
   }
 
@@ -116,7 +118,7 @@ export class Handle<T> {
   };
 
   debug() {
-    this.repo.debug(this.id);
+    this.repo.debug(this.url);
   }
 
   cleanup = () => {};

--- a/src/Keys.ts
+++ b/src/Keys.ts
@@ -1,15 +1,28 @@
 import * as Base58 from "bs58";
-
+import * as crypto from "hypercore/lib/crypto";
 
 export interface KeyBuffer {
-    publicKey: Buffer;
-    secretKey?: Buffer;
+  publicKey: Buffer;
+  secretKey?: Buffer;
+}
+
+export interface KeyPair {
+  publicKey: string
+  secretKey: string
+}
+
+export function create(): KeyPair {
+  const keys = crypto.keyPair()
+  return {
+    publicKey: encode(keys.publicKey),
+    secretKey: encode(keys.secretKey)
+  }
 }
 
 export function decode(key: string): Buffer {
-    return Base58.decode(key)
+  return Base58.decode(key)
 }
 
 export function encode(key: Buffer): string {
-    return Base58.encode(key)
+  return Base58.encode(key)
 }

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -22,12 +22,20 @@ export function encodeDiscoveryId(discoveryKey: Buffer): DiscoveryId {
   return Base58.encode(discoveryKey) as DiscoveryId
 }
 
+export function encodeHyperfileId(hyperfileKey: Buffer): HyperfileId {
+  return Base58.encode(hyperfileKey) as HyperfileId
+}
+
 export function asDocUrl(docId: DocId): DocUrl {
   return `hypermerge:/${docId}` as DocUrl
 }
 
 export function rootActorId(docId: DocId): ActorId {
   return docId as string as ActorId
+}
+
+export function hyperfileActorId(hyperfileId: HyperfileId): ActorId {
+  return hyperfileId as string as ActorId
 }
 
 export function isBaseUrl(str: BaseUrl | BaseId): str is BaseUrl {

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -30,6 +30,10 @@ export function asDocUrl(docId: DocId): DocUrl {
   return `hypermerge:/${docId}` as DocUrl
 }
 
+export function asHyperfileUrl(hyperfileId: HyperfileId): HyperfileUrl {
+  return `hyperfile:/${hyperfileId}` as HyperfileUrl
+}
+
 export function rootActorId(docId: DocId): ActorId {
   return docId as string as ActorId
 }

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -1,3 +1,39 @@
+import * as Base58 from "bs58"
+
+export type BaseId = string & { id: true }
+export type DocId = BaseId & { docId: true }
+export type ActorId = BaseId & { actorId: true }
+export type HyperfileId = BaseId & { hyperfileId: true }
+export type DiscoveryId = BaseId & { discoveryId: true }
+
+export type BaseUrl = string & { url: true }
+export type DocUrl = BaseUrl & { docUrl: true }
+export type HyperfileUrl = BaseUrl & { hyperfileUrl: true }
+
+export function encodeDocId(actorKey: Buffer): DocId {
+  return Base58.encode(actorKey) as DocId
+}
+
+export function encodeActorId(actorKey: Buffer): ActorId {
+  return Base58.encode(actorKey) as ActorId
+}
+
+export function encodeDiscoveryId(discoveryKey: Buffer): DiscoveryId {
+  return Base58.encode(discoveryKey) as DiscoveryId
+}
+
+export function asDocUrl(docId: DocId): DocUrl {
+  return `hypermerge:/${docId}` as DocUrl
+}
+
+export function rootActorId(docId: DocId): ActorId {
+  return docId as string as ActorId
+}
+
+export function isBaseUrl(str: BaseUrl | BaseId): str is BaseUrl {
+  return str.includes(":")
+}
+
 export function joinSets<T>(sets: Set<T>[]): Set<T> {
   const total = ([] as T[]).concat(...sets.map(a => [...a]));
   return new Set(total);

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -26,11 +26,11 @@ export function encodeHyperfileId(hyperfileKey: Buffer): HyperfileId {
   return Base58.encode(hyperfileKey) as HyperfileId
 }
 
-export function asDocUrl(docId: DocId): DocUrl {
+export function toDocUrl(docId: DocId): DocUrl {
   return `hypermerge:/${docId}` as DocUrl
 }
 
-export function asHyperfileUrl(hyperfileId: HyperfileId): HyperfileUrl {
+export function toHyperfileUrl(hyperfileId: HyperfileId): HyperfileUrl {
   return `hyperfile:/${hyperfileId}` as HyperfileUrl
 }
 

--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -3,6 +3,7 @@ import { RepoFrontend, DocMetadata } from "./RepoFrontend";
 import { Handle } from "./Handle";
 import { PublicMetadata } from "./Metadata";
 import { Clock } from "./Clock";
+import { DocUrl, HyperfileUrl } from "./Misc";
 
 interface Swarm {
   join(dk: Buffer): void;
@@ -15,26 +16,26 @@ export class Repo {
   back: RepoBackend;
   id: Buffer;
   stream: (opts: any) => any;
-  create: <T>(init?: T) => string;
-  open: <T>(id: string) => Handle<T>;
-  destroy: (id: string) => void;
+  create: <T>(init?: T) => DocUrl;
+  open: <T>(id: DocUrl) => Handle<T>;
+  destroy: (id: DocUrl) => void;
   //follow: (id: string, target: string) => void;
   replicate: (swarm: Swarm) => void;
 
-  message: (id: string, message: any) => void;
+  message: (url: DocUrl, message: any) => void;
 
-  fork: (id: string) => string;
+  fork: (url: DocUrl) => DocUrl;
   watch: <T>(
-    id: string,
+    url: DocUrl,
     cb: (val: T, clock?: Clock, index?: number) => void
   ) => Handle<T>;
-  doc: <T>(id: string, cb?: (val: T, clock?: Clock) => void) => Promise<T>;
-  merge: (id: string, target: string) => void;
-  change: <T>(id: string, fn: (state:T) => void) => void;
-  writeFile: <T>(data: Uint8Array, mimeType: string) => string;
-  readFile: <T>(id: string, cb: (data: Uint8Array, mimeType: string) => void) => void;
-  materialize: <T>(id: string, seq: number, cb: (val: T) => void) => void;
-  meta: (id: string, cb: (meta: PublicMetadata | undefined) => void) => void;
+  doc: <T>(url: DocUrl, cb?: (val: T, clock?: Clock) => void) => Promise<T>;
+  merge: (url: DocUrl, target: DocUrl) => void;
+  change: <T>(url: DocUrl, fn: (state:T) => void) => void;
+  writeFile: (data: Uint8Array, mimeType: string) => HyperfileUrl;
+  readFile: (url: HyperfileUrl, cb: (data: Uint8Array, mimeType: string) => void) => void;
+  materialize: <T>(url: DocUrl, seq: number, cb: (val: T) => void) => void;
+  meta: (url: DocUrl | HyperfileUrl, cb: (meta: PublicMetadata | undefined) => void) => void;
   close: () => void;
 
   constructor(opts: Options) {

--- a/src/RepoBackend.ts
+++ b/src/RepoBackend.ts
@@ -9,7 +9,7 @@ import * as Backend from "automerge/backend";
 import { Clock, Change } from "automerge/backend";
 import { ToBackendQueryMsg, ToBackendRepoMsg, ToFrontendReplyMsg, ToFrontendRepoMsg, DocumentMsg } from "./RepoMsg";
 import * as DocBackend from "./DocBackend"
-import { notEmpty, ID, ActorId, DiscoveryId, DocId, HyperfileId, encodeDocId, rootActorId, encodeDiscoveryId, encodeActorId } from "./Misc";
+import { notEmpty, ID, ActorId, DiscoveryId, DocId, HyperfileId, encodeDocId, rootActorId, encodeDiscoveryId, encodeActorId, encodeHyperfileId, hyperfileActorId } from "./Misc";
 import Debug from "debug";
 import * as DocumentBroadcast from "./DocumentBroadcast"
 import * as Keys from "./Keys"
@@ -61,7 +61,7 @@ export class RepoBackend {
   }
 
   private writeFile(keys: Keys.KeyBuffer, data: Uint8Array, mimeType: string) {
-    const fileId = Keys.encode(keys.publicKey) as HyperfileId;
+    const fileId = encodeHyperfileId(keys.publicKey);
 
     this.meta.addFile(fileId, data.length, mimeType);
 
@@ -72,7 +72,7 @@ export class RepoBackend {
   private async readFile(id: HyperfileId): Promise<{body: Uint8Array, mimeType: string}> {
 //    log("readFile",id, this.meta.forDoc(id))
     if (this.meta.isDoc(id)) { throw new Error("trying to open a document like a file") }
-    const actor = await this.getReadyActor(id as unknown as ActorId)
+    const actor = await this.getReadyActor(hyperfileActorId(id))
     return actor.readFile()
   }
 

--- a/src/RepoFrontend.ts
+++ b/src/RepoFrontend.ts
@@ -11,7 +11,7 @@ import * as Keys from './Keys'
 import Debug from "debug";
 import { PublicMetadata, validateDocURL, validateFileURL, validateURL } from "./Metadata";
 import mime from "mime-types";
-import { DocUrl, DocId, ActorId, asDocUrl, HyperfileId, HyperfileUrl, rootActorId, asHyperfileUrl } from "./Misc";
+import { DocUrl, DocId, ActorId, toDocUrl, HyperfileId, HyperfileUrl, rootActorId, toHyperfileUrl } from "./Misc";
 
 Debug.formatters.b = Base58.encode;
 
@@ -56,7 +56,7 @@ export class RepoFrontend {
         }
       });
     }
-    return asDocUrl(docId);
+    return toDocUrl(docId);
   };
 
   change = <T>(url: DocUrl, fn: (state: T) => void ) => {
@@ -107,7 +107,7 @@ export class RepoFrontend {
     }
     this.toBackend.push(data);
     this.toBackend.push({ type: "WriteFile", publicKey, secretKey, mimeType });
-    return asHyperfileUrl(hyperfileId)
+    return toHyperfileUrl(hyperfileId)
   };
 
   readFile = <T>(url: HyperfileUrl, cb: (data: Uint8Array, mimeType: string) => void): void => {

--- a/src/RepoFrontend.ts
+++ b/src/RepoFrontend.ts
@@ -9,8 +9,9 @@ import * as Frontend from "automerge/frontend";
 import { DocFrontend } from "./DocFrontend";
 import { clock2strs, Clock, clockDebug } from "./Clock";
 import Debug from "debug";
-import { PublicMetadata, validateDocURL, validateFileURL, validateURL } from "./Metadata";
+import { PublicMetadata, validateDocURL, validateFileURL, validateURL, PublicDocMetadata } from "./Metadata";
 import mime from "mime-types";
+import { DocUrl, DocId, ActorId, asDocUrl, HyperfileId, HyperfileUrl } from "./Misc";
 
 Debug.formatters.b = Base58.encode;
 
@@ -19,11 +20,11 @@ const log = Debug("repo:front");
 export interface DocMetadata {
   clock: Clock;
   history: number;
-  actor?: string;
+  actor?: ActorId;
 }
 
 export interface ProgressEvent {
-  actor: string;
+  actor: ActorId;
   index: number;
   size: number;
   time: number;
@@ -33,18 +34,18 @@ let msgid = 1
 
 export class RepoFrontend {
   toBackend: Queue<ToBackendRepoMsg> = new Queue("repo:front:toBackendQ");
-  docs: Map<string, DocFrontend<any>> = new Map();
+  docs: Map<DocId, DocFrontend<any>> = new Map();
   cb: Map<number, (reply: any) => void> = new Map();
   msgcb: Map<number, (patch: Patch) => void> = new Map();
-  readFiles: MapSet<string, (data: Uint8Array, mimeType: string) => void> = new MapSet();
+  readFiles: MapSet<HyperfileId, (data: Uint8Array, mimeType: string) => void> = new MapSet();
   file?: Uint8Array;
 
-  create = <T>(init?: T): string => {
+  create = <T>(init?: T): DocUrl => {
     const keys = crypto.keyPair();
     const publicKey = Base58.encode(keys.publicKey);
     const secretKey = Base58.encode(keys.secretKey);
-    const docId = publicKey;
-    const actorId = publicKey;
+    const docId = publicKey as DocId;
+    const actorId = publicKey as ActorId;
     const doc = new DocFrontend(this, { actorId, docId });
     this.docs.set(docId, doc);
     this.toBackend.push({ type: "CreateMsg", publicKey, secretKey });
@@ -55,18 +56,18 @@ export class RepoFrontend {
         }
       });
     }
-    return `hypermerge:/${docId}`;
+    return asDocUrl(docId);
   };
 
-  change = <T>(id: string, fn: (state: T) => void ) => {
-    this.open<T>(id).change(fn);
+  change = <T>(url: DocUrl, fn: (state: T) => void ) => {
+    this.open<T>(url).change(fn);
   };
 
-  meta = (url: string, cb:(meta: PublicMetadata | undefined) => void): void => {
+  meta = (url: DocUrl | HyperfileUrl, cb:(meta: PublicMetadata | undefined) => void): void => {
     const {id , type} = validateURL(url);
-    this.queryBackend({ type: "MetadataMsg", id }, (meta: PublicMetadata | undefined) => {
+    this.queryBackend({ type: "MetadataMsg", id: id as DocId | HyperfileId }, (meta: PublicMetadata | undefined) => {
       if (meta) {
-      const doc = this.docs.get(id);
+      const doc = this.docs.get(id as DocId);
         if (doc && meta.type === "Document") {
           meta.actor = doc.actorId
           meta.history = doc.history
@@ -77,9 +78,9 @@ export class RepoFrontend {
     })
   }
 
-  meta2 = (url: string): DocMetadata | undefined => {
+  meta2 = (url: DocUrl | HyperfileUrl): DocMetadata | undefined => {
     const {id , type} = validateURL(url);
-    const doc = this.docs.get(id);
+    const doc = this.docs.get(id as DocId);
     if (!doc) return;
     return {
       actor: doc.actorId,
@@ -88,7 +89,7 @@ export class RepoFrontend {
     };
   };
 
-  merge = (url: string, target: string) => {
+  merge = (url: DocUrl, target: DocUrl) => {
     const id = validateDocURL(url);
     validateDocURL(target);
     this.doc(target, (doc, clock) => {
@@ -97,7 +98,7 @@ export class RepoFrontend {
     });
   };
 
-  writeFile = <T>(data: Uint8Array, mimeType: string): string => {
+  writeFile = <T>(data: Uint8Array, mimeType: string): HyperfileUrl => {
     const keys = crypto.keyPair();
     const publicKey = Base58.encode(keys.publicKey);
     const secretKey = Base58.encode(keys.secretKey);
@@ -106,16 +107,16 @@ export class RepoFrontend {
     }
     this.toBackend.push(data);
     this.toBackend.push({ type: "WriteFile", publicKey, secretKey, mimeType });
-    return `hyperfile:/${publicKey}`;
+    return `hyperfile:/${publicKey}` as HyperfileUrl;
   };
 
-  readFile = <T>(url: string, cb: (data: Uint8Array, mimeType: string) => void): void => {
+  readFile = <T>(url: HyperfileUrl, cb: (data: Uint8Array, mimeType: string) => void): void => {
     const id = validateFileURL(url);
     this.readFiles.add(id, cb);
     this.toBackend.push({ type: "ReadFile", id });
   };
 
-  fork = (url: string): string => {
+  fork = (url: DocUrl): DocUrl => {
     validateDocURL(url);
     const fork = this.create();
     this.merge(fork, url);
@@ -129,19 +130,19 @@ export class RepoFrontend {
   };
 */
 
-  watch = <T>( url: string, cb: (val: T, clock?: Clock, index?: number) => void): Handle<T> => {
+  watch = <T>( url: DocUrl, cb: (val: T, clock?: Clock, index?: number) => void): Handle<T> => {
     validateDocURL(url);
     const handle = this.open<T>(url);
     handle.subscribe(cb);
     return handle;
   };
 
-  message = ( url: string, contents: any): void => {
+  message = ( url: DocUrl, contents: any): void => {
     const id = validateDocURL(url);
     this.toBackend.push({type: "DocumentMessage", id, contents})
   }
 
-  doc = <T>(url: string, cb?: (val: T, clock?: Clock) => void): Promise<T> => {
+  doc = <T>(url: DocUrl, cb?: (val: T, clock?: Clock) => void): Promise<T> => {
     validateDocURL(url);
     return new Promise(resolve => {
       const handle = this.open<T>(url);
@@ -153,7 +154,7 @@ export class RepoFrontend {
     });
   };
 
-  materialize = <T>(url: string, history: number, cb: (val: T) => void) => {
+  materialize = <T>(url: DocUrl, history: number, cb: (val: T) => void) => {
     const id = validateDocURL(url);
     const doc = this.docs.get(id);
     if (doc === undefined) { throw new Error(`No such document ${id}`) }
@@ -171,13 +172,13 @@ export class RepoFrontend {
     this.toBackend.push({type: "Query", id, query})
   }
 
-  open = <T>(url: string): Handle<T> => {
+  open = <T>(url: DocUrl): Handle<T> => {
     const id = validateDocURL(url);
     const doc: DocFrontend<T> = this.docs.get(id) || this.openDocFrontend(id);
     return doc.handle();
   }
 
-  debug(url: string) {
+  debug(url: DocUrl) {
     const id = validateDocURL(url);
     const doc = this.docs.get(id);
     const short = id.substr(0, 5);
@@ -191,7 +192,7 @@ export class RepoFrontend {
     this.toBackend.push({ type: "DebugMsg", id });
   }
 
-  private openDocFrontend<T>(id: string): DocFrontend<T> {
+  private openDocFrontend<T>(id: DocId): DocFrontend<T> {
     const doc: DocFrontend<T> = new DocFrontend(this, { docId: id });
     this.toBackend.push({ type: "OpenMsg", id });
     this.docs.set(id, doc);
@@ -208,8 +209,8 @@ export class RepoFrontend {
     this.docs.clear()
   }
 
-  destroy = (url: string) : void => {
-    const { id } = validateURL(url);
+  destroy = (url: DocUrl) : void => {
+    const id = validateDocURL(url);
     this.toBackend.push({ type: "DestroyMsg", id });
     const doc = this.docs.get(id);
     if (doc) {

--- a/src/RepoMsg.ts
+++ b/src/RepoMsg.ts
@@ -1,5 +1,6 @@
 import { Patch, Change } from "automerge/frontend";
 import { PublicMetadata } from "./Metadata"
+import { DocId, HyperfileId, ActorId } from "./Misc";
 
 export type ToBackendQueryMsg =
   | MaterializeMsg
@@ -41,13 +42,13 @@ export interface ReplyMsg {
 
 export interface MaterializeMsg {
   type: "MaterializeMsg";
-  id: string;
+  id: DocId;
   history: number;
 }
 
 export interface MetadataMsg {
   type: "MetadataMsg";
-  id: string;
+  id: DocId | HyperfileId;
 }
 
 export interface CreateMsg {
@@ -65,13 +66,13 @@ export interface WriteFile {
 
 export interface ReadFile {
   type: "ReadFile";
-  id: string;
+  id: HyperfileId;
 }
 
 export interface MergeMsg {
   type: "MergeMsg";
-  id: string;
-  actors: string[];
+  id: DocId;
+  actors: string[]; // ActorId | `${ActorId}-${seq}`
 }
 
 /*
@@ -84,27 +85,27 @@ export interface FollowMsg {
 
 export interface DebugMsg {
   type: "DebugMsg";
-  id: string;
+  id: DocId;
 }
 
 export interface OpenMsg {
   type: "OpenMsg";
-  id: string;
+  id: DocId;
 }
 
 export interface DestroyMsg {
   type: "DestroyMsg";
-  id: string;
+  id: DocId;
 }
 
 export interface NeedsActorIdMsg {
   type: "NeedsActorIdMsg";
-  id: string;
+  id: DocId;
 }
 
 export interface RequestMsg {
   type: "RequestMsg";
-  id: string;
+  id: DocId;
   request: Change;
 }
 
@@ -120,7 +121,7 @@ export type ToFrontendRepoMsg =
 
 export interface PatchMsg {
   type: "PatchMsg";
-  id: string;
+  id: DocId;
   synced: boolean;
   patch: Patch;
   history: number;
@@ -128,7 +129,7 @@ export interface PatchMsg {
 
 export interface DocumentMsg {
   type: "DocumentMessage";
-  id: string;
+  id: DocId;
   contents: any;
 }
 
@@ -144,14 +145,14 @@ export interface MetadataReplyMsg {
 
 export interface ReadFileReply {
   type: "ReadFileReply";
-  id: string;
+  id: HyperfileId;
   mimeType: string;
 }
 
 export interface ActorIdMsg {
   type: "ActorIdMsg";
-  id: string;
-  actorId: string;
+  id: DocId;
+  actorId: ActorId;
 }
 
 export interface CloseMsg {
@@ -160,17 +161,17 @@ export interface CloseMsg {
 
 export interface ReadyMsg {
   type: "ReadyMsg";
-  id: string;
+  id: DocId;
   synced: boolean;
-  actorId?: string;
+  actorId?: ActorId;
   patch?: Patch;
   history?: number;
 }
 
 export interface ActorBlockDownloadedMsg {
   type: "ActorBlockDownloadedMsg";
-  id: string;
-  actorId: string;
+  id: DocId;
+  actorId: ActorId;
   index: number;
   size: number;
   time: number;

--- a/src/RepoMsg.ts
+++ b/src/RepoMsg.ts
@@ -72,7 +72,7 @@ export interface ReadFile {
 export interface MergeMsg {
   type: "MergeMsg";
   id: DocId;
-  actors: string[]; // ActorId | `${ActorId}-${seq}`
+  actors: string[]; // ActorId | `${ActorId}:${seq}` (result of clock2strs function)
 }
 
 /*

--- a/src/hypercore.ts
+++ b/src/hypercore.ts
@@ -1,122 +1,136 @@
-declare function require(moduleName: string): any;
+declare function require(moduleName: string): any
 
-let _hypercore = require("hypercore");
+let _hypercore = require("hypercore")
 
-import Debug from "debug";
-import { ID } from "./Misc";
-const log = Debug("repo:hypermerge");
+import Debug from "debug"
+import { ID, ActorId } from "./Misc"
+const log = Debug("repo:hypermerge")
 
-type Key = string | Buffer;
-type Storage = string | Function;
+type Key = string | Buffer
+type Storage = string | Function
 
 export interface Options {
-  secretKey?: Key;
-  valueEncoding?: string;
+  secretKey?: Key
+  valueEncoding?: string
 }
 
 export interface ReadOpts {
-  wait?: boolean;
-  timeout?: number;
-  valueEncoding?: string;
+  wait?: boolean
+  timeout?: number
+  valueEncoding?: string
 }
 
 export function discoveryKey(buf: Buffer): Buffer {
-  return _hypercore.discoveryKey(buf);
+  return _hypercore.discoveryKey(buf)
 }
 
-export function hypercore<T>(storage: Storage, options: Options): Feed<T>;
+export function hypercore<T>(storage: Storage, options: Options): Feed<T>
 export function hypercore<T>(
   storage: Storage,
   key: Key,
-  options: Options
-): Feed<T>;
+  options: Options,
+): Feed<T>
 export function hypercore<T>(storage: Storage, arg2: any, arg3?: any): Feed<T> {
   if (arg3) {
-    return _hypercore(storage, arg2, arg3);
+    return _hypercore(storage, arg2, arg3)
   } else {
-    return _hypercore(storage, arg2);
+    return _hypercore(storage, arg2)
   }
 }
 
 export interface Feed<T> {
-  on(event: "ready", cb: () => void): this;
-  on(event: "close", cb: () => void): this;
-  on(event: "sync", cb: () => void): this;
-  on(event: "error", cb: (err: Error) => void): this;
-  on(event: "download", cb: (index: number, data: Buffer) => void): this;
-  on(event: "upload", cb: (index: number, data: T) => void): this;
-  on(event: "data", cb: (idx: number, data: T) => void): this;
-  on(event: "peer-add", cb: (peer: Peer) => void): this;
-  on(event: "peer-remove", cb: (peer: Peer) => void): this;
-  on(event: "extension", cb: (a: any, b: any) => void): this;
+  on(event: "ready", cb: () => void): this
+  on(event: "close", cb: () => void): this
+  on(event: "sync", cb: () => void): this
+  on(event: "error", cb: (err: Error) => void): this
+  on(event: "download", cb: (index: number, data: Buffer) => void): this
+  on(event: "upload", cb: (index: number, data: T) => void): this
+  on(event: "data", cb: (idx: number, data: T) => void): this
+  on(event: "peer-add", cb: (peer: Peer) => void): this
+  on(event: "peer-remove", cb: (peer: Peer) => void): this
+  on(event: "extension", cb: (a: any, b: any) => void): this
 
-  peers: Peer[];
-  replicate: Function;
-  writable: boolean;
-  ready: Function;
-  append(data: T): void;
-  append(data: T, cb: (err: Error | null) => void): void;
-  clear(index:number, cb:() => void) : void;
-  clear(start:number, end: number, cb:() => void) : void;
-  downloaded() : number;
-  downloaded(start: number) : number;
-  downloaded(start: number, end: number) : number;
-  has(index:number) : boolean;
-  has(start:number,end:number) : boolean;
-  signature(cb:(err: any, sig: any) => void) : void;
-  signature(index: number, cb:(err: any, sig: any) => void) : void;
-  verify(index: number, sig: Buffer, cb:(err: any, roots: any) => void) : void;
-  close(cb: (err: Error) => void): void;
-  get(index: number, cb: (err: Error, data: T) => void): void;
-  get(index: number, config: any, cb: (err: Error, data: T) => void): void;
-  getBatch(start: number, end: number, cb: (Err: any, data: T[]) => void): void;
-  getBatch(start: number, end: number, config: any, cb: (Err: any, data: T[]) => void): void;
-  discoveryKey: Buffer;
-  id: Buffer;
-  length: number;
+  peers: Peer[]
+  replicate: Function
+  writable: boolean
+  ready: Function
+  append(data: T): void
+  append(data: T, cb: (err: Error | null) => void): void
+  clear(index: number, cb: () => void): void
+  clear(start: number, end: number, cb: () => void): void
+  downloaded(): number
+  downloaded(start: number): number
+  downloaded(start: number, end: number): number
+  has(index: number): boolean
+  has(start: number, end: number): boolean
+  signature(cb: (err: any, sig: any) => void): void
+  signature(index: number, cb: (err: any, sig: any) => void): void
+  verify(index: number, sig: Buffer, cb: (err: any, roots: any) => void): void
+  close(cb: (err: Error) => void): void
+  get(index: number, cb: (err: Error, data: T) => void): void
+  get(index: number, config: any, cb: (err: Error, data: T) => void): void
+  getBatch(start: number, end: number, cb: (Err: any, data: T[]) => void): void
+  getBatch(
+    start: number,
+    end: number,
+    config: any,
+    cb: (Err: any, data: T[]) => void,
+  ): void
+  discoveryKey: Buffer
+  id: Buffer
+  length: number
 }
 
-function readFeedN<T>(id: string, feed: Feed<T>, index: number, cb: (data: T[]) => void) {
+function readFeedN<T>(
+  id: ActorId | "ledger",
+  feed: Feed<T>,
+  index: number,
+  cb: (data: T[]) => void,
+) {
   log(`readFeedN id=${ID(id)} (0..${index})`)
 
   if (index === 0) {
     feed.get(0, { wait: false }, (err, data) => {
-      if (err) log(`feed.get() error id=${ID(id)}`,err)
-      if (err) throw err;
+      if (err) log(`feed.get() error id=${ID(id)}`, err)
+      if (err) throw err
       cb([data])
     })
   } else {
     feed.getBatch(0, index, { wait: false }, (err, data) => {
-      if (err) log(`feed.getBatch error id=${ID(id)}`,err)
-      if (err) throw err;
+      if (err) log(`feed.getBatch error id=${ID(id)}`, err)
+      if (err) throw err
       cb(data)
     })
   }
 }
 
-export function readFeed<T>(id: string, feed: Feed<T>, cb: (data: T[]) => void) {
-//  const id = feed.id.toString('hex').slice(0,4)
+export function readFeed<T>(
+  id: ActorId | "ledger",
+  feed: Feed<T>,
+  cb: (data: T[]) => void,
+) {
+  //  const id = feed.id.toString('hex').slice(0,4)
   const length = feed.downloaded()
 
   log(`readFeed ${ID(id)} downloaded=${length} feed.length=${feed.length}`)
 
   if (length === 0) return cb([])
-  if (feed.has(0, length)) return readFeedN(id, feed,length, cb)
+  if (feed.has(0, length)) return readFeedN(id, feed, length, cb)
 
   for (let i = 0; i < length; i++) {
     if (!feed.has(i)) {
-        feed.clear(i, feed.length, () => {
-        log(`post clear -- readFeedN id=${ID(id)} n=${i-1}`)
+      feed.clear(i, feed.length, () => {
+        log(`post clear -- readFeedN id=${ID(id)} n=${i - 1}`)
         readFeedN(id, feed, i - 1, cb)
       })
-      break;
+      break
     }
   }
 }
 
 export interface Peer {
-  feed: any;
-  stream: any;
-  onextension: any;
+  feed: any
+  stream: any
+  onextension: any
   remoteId: Buffer
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { RepoFrontend } from "./RepoFrontend";
 
 export { DocBackend } from "./DocBackend";
 export { DocFrontend } from "./DocFrontend";
+export { DocUrl, HyperfileUrl } from "./Misc";


### PR DESCRIPTION
A number of bugs and frustrations have stemmed from the conflation of actor ids with document ids (and others) in the code-base. This PR is a step towards solving this problem.

In the future, it's possible we'll change the actual string values of these types to be more distinct, but we can start by helping the type-checker do its job.

The PR adds 8 new types:

```
export type BaseId = string & { id: true }
export type DocId = BaseId & { docId: true }
export type ActorId = BaseId & { actorId: true }
export type HyperfileId = BaseId & { hyperfileId: true }
export type DiscoveryId = BaseId & { discoveryId: true }

export type BaseUrl = string & { url: true }
export type DocUrl = BaseUrl & { docUrl: true }
export type HyperfileUrl = BaseUrl & { hyperfileUrl: true }
```

The values represented by these types are still `string`s, but the type-checker sees them as a unique (unconstructable) sub-type of `string`: `DocUrl` can be used as a `string`, but not vice versa.

All of the internal and external functions have been updated to use these types. In particular, if you're using TypeScript, the Repo and Handle methods (e.g. `repo.open(url: DocUrl)`) will no longer type-check if plain `string`s are passed in. Instead, use the result of `repo.create(): DocUrl` as the url or typecast the url: `repo.open(urlString as DocUrl)`.