### PR TITLE
Use RepoId for ClockStore

### DIFF
--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream'
 import { FeedId } from './FeedStore'
 
 export type BaseId = string & { id: true }
+export type RepoId = BaseId & { repoId: true }
 export type DocId = BaseId & { docId: true }
 export type ActorId = FeedId & { actorId: true }
 export type HyperfileId = BaseId & { hyperfileId: true }
@@ -11,6 +12,10 @@ export type DiscoveryId = BaseId & { discoveryId: true }
 export type BaseUrl = string & { url: true }
 export type DocUrl = BaseUrl & { docUrl: true }
 export type HyperfileUrl = BaseUrl & { hyperfileUrl: true }
+
+export function encodeRepoId(repoKey: Buffer): RepoId {
+  return Base58.encode(repoKey) as RepoId
+}
 
 export function encodeDocId(actorKey: Buffer): DocId {
   return Base58.encode(actorKey) as DocId

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -1,4 +1,3 @@
-import { Duplex } from 'stream'
 import * as Base58 from 'bs58'
 import HypercoreProtocol from 'hypercore-protocol'
 import { DiscoveryId, encodeDiscoveryId } from './Misc'

--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -12,7 +12,7 @@ export class Repo {
   front: RepoFrontend
   back: RepoBackend
   id: RepoId
-  swarmId: Buffer
+  swarmKey: Buffer
   stream: (opts: any) => any
   create: <T>(init?: T) => DocUrl
   open: <T>(id: DocUrl) => Handle<T>
@@ -39,7 +39,7 @@ export class Repo {
     this.front = new RepoFrontend()
     this.front.subscribe(this.back.receive)
     this.back.subscribe(this.front.receive)
-    this.swarmId = this.back.swarmId
+    this.swarmKey = this.back.swarmKey
     this.id = this.back.id
     this.stream = this.back.stream
     this.create = this.front.create

--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -3,7 +3,7 @@ import { RepoFrontend } from './RepoFrontend'
 import { Handle } from './Handle'
 import { PublicMetadata } from './Metadata'
 import { Clock } from './Clock'
-import { DocUrl, HyperfileUrl } from './Misc'
+import { DocUrl, HyperfileUrl, RepoId } from './Misc'
 import FileServerClient from './FileServerClient'
 import { Swarm } from './Network'
 import { Doc, Proxy } from 'automerge'
@@ -11,7 +11,8 @@ import { Doc, Proxy } from 'automerge'
 export class Repo {
   front: RepoFrontend
   back: RepoBackend
-  id: Buffer
+  id: RepoId
+  swarmId: Buffer
   stream: (opts: any) => any
   create: <T>(init?: T) => DocUrl
   open: <T>(id: DocUrl) => Handle<T>
@@ -38,6 +39,7 @@ export class Repo {
     this.front = new RepoFrontend()
     this.front.subscribe(this.back.receive)
     this.back.subscribe(this.front.receive)
+    this.swarmId = this.back.swarmId
     this.id = this.back.id
     this.stream = this.back.stream
     this.create = this.front.create

--- a/src/RepoBackend.ts
+++ b/src/RepoBackend.ts
@@ -64,7 +64,7 @@ export class RepoBackend {
   opts: Options
   toFrontend: Queue<ToFrontendRepoMsg> = new Queue('repo:back:toFrontend')
   id: RepoId
-  swarmId: Buffer // TODO: Remove this once we no longer use discovery-swarm/discovery-cloud
+  swarmKey: Buffer // TODO: Remove this once we no longer use discovery-swarm/discovery-cloud
   private db: SqlDatabase.Database
   private fileServer: FileServer
   private network: Network
@@ -84,7 +84,7 @@ export class RepoBackend {
 
     // init repo
     const repoKeys = this.keys.get('self.repo') || this.keys.set('self.repo', Keys.createBuffer())
-    this.swarmId = repoKeys.publicKey
+    this.swarmKey = repoKeys.publicKey
     this.id = encodeRepoId(repoKeys.publicKey)
 
     // initialize the various stores

--- a/src/migrations/0001_initial_schema.sql
+++ b/src/migrations/0001_initial_schema.sql
@@ -1,8 +1,9 @@
-CREATE TABLE IF NOT EXISTS Clock (
+CREATE TABLE IF NOT EXISTS Clocks (
+    repoId TEXT NOT NULL,
     documentId TEXT NOT NULL,
     actorId TEXT NOT NULL,
     seq INTEGER NOT NULL,
-    PRIMARY KEY (documentId, actorId)
+    PRIMARY KEY (repoId, documentId, actorId)
 ) WITHOUT ROWID;
 
 CREATE TABLE IF NOT EXISTS Keys (

--- a/tests/ClockStore.test.ts
+++ b/tests/ClockStore.test.ts
@@ -1,18 +1,19 @@
 import test from 'tape'
 import * as SqlDatabase from '../src/SqlDatabase'
 import ClockStore from '../src/ClockStore'
-import { DocId } from '../src/Misc'
+import { RepoId, DocId } from '../src/Misc'
 
 test('ClockStore', (t) => {
   t.test('read and write', async (t) => {
     t.plan(1)
+    const repoId = 'repoId' as RepoId
     const db = SqlDatabase.open('test.db', true)
     const clockStore = new ClockStore(db)
 
     const docId = 'abc123' as DocId
     const clock = { abc123: 1, def456: 0 }
-    clockStore.update(docId, clock)
-    const readClock = clockStore.get(docId)
+    clockStore.update(repoId, docId, clock)
+    const readClock = clockStore.get(repoId, docId)
     t.deepEqual(readClock, clock)
 
     db.close()
@@ -23,12 +24,13 @@ test('ClockStore', (t) => {
     const db = SqlDatabase.open('test.db', true)
     const clockStore = new ClockStore(db)
 
+    const repoId = 'repoId' as RepoId
     const docId = 'abc123' as DocId
     const clock = { abc123: 1, def456: 0 }
-    clockStore.update(docId, clock)
+    clockStore.update(repoId, docId, clock)
     const updatedClock = { abc123: 2, def456: 0 }
-    clockStore.update(docId, updatedClock)
-    const readClock = clockStore.get(docId)
+    clockStore.update(repoId, docId, updatedClock)
+    const readClock = clockStore.get(repoId, docId)
     t.deepEqual(readClock, updatedClock)
     db.close()
   })
@@ -38,12 +40,13 @@ test('ClockStore', (t) => {
     const db = SqlDatabase.open('test.db', true)
     const clockStore = new ClockStore(db)
 
+    const repoId = 'repoId' as RepoId
     const docId = 'abc123' as DocId
     const clock = { abc123: 1, def456: 0 }
-    clockStore.set(docId, clock)
+    clockStore.set(repoId, docId, clock)
     const updatedClock = { abc123: 2 }
-    clockStore.set(docId, updatedClock)
-    const readClock = clockStore.get(docId)
+    clockStore.set(repoId, docId, updatedClock)
+    const readClock = clockStore.get(repoId, docId)
     t.deepEqual(readClock, updatedClock)
     db.close()
   })
@@ -53,15 +56,16 @@ test('ClockStore', (t) => {
     const db = SqlDatabase.open('test.db', true)
     const clockStore = new ClockStore(db)
 
+    const repoId = 'repoId' as RepoId
     const docId = 'abc123' as DocId
     const clock = { abc123: 1, def456: 0 }
-    clockStore.update(docId, clock)
+    clockStore.update(repoId, docId, clock)
 
     const docId2 = 'ghi789' as DocId
     const clock2 = { ghi789: 2, jkl012: 0 }
-    clockStore.update(docId2, clock2)
+    clockStore.update(repoId, docId2, clock2)
 
-    const clocks = clockStore.getMultiple([docId, docId2])
+    const clocks = clockStore.getMultiple(repoId, [docId, docId2])
     const expectedClocks = {
       [docId]: clock,
       [docId2]: clock2,

--- a/tests/ClockStore.test.ts
+++ b/tests/ClockStore.test.ts
@@ -73,4 +73,58 @@ test('ClockStore', (t) => {
     t.deepEqual(clocks, expectedClocks)
     db.close()
   })
+
+  t.test('get with multiple repos', (t) => {
+    t.plan(2)
+    const db = SqlDatabase.open('test.db', true)
+    const clockStore = new ClockStore(db)
+
+    const repoId = 'repoId' as RepoId
+    const docId = 'abc123' as DocId
+    const clock = { abc123: 1, def456: 0 }
+    clockStore.update(repoId, docId, clock)
+
+    const docId2 = 'ghi789' as DocId
+    const clock2 = { ghi789: 2, jkl012: 0 }
+    clockStore.update(repoId, docId2, clock2)
+
+    const repoId2 = 'repoId2' as RepoId
+    const clock3 = { abc123: 1, def456: 1 }
+    clockStore.update(repoId2, docId, clock3)
+
+    const res2 = clockStore.get(repoId2, docId)
+
+    const clocks = clockStore.getMultiple(repoId, [docId, docId2])
+    const expectedClocks = {
+      [docId]: clock,
+      [docId2]: clock2,
+    }
+    t.deepEqual(clocks, expectedClocks)
+    t.deepEqual(res2, clock3)
+    db.close()
+  })
+
+  t.test('update with multiple repos', (t) => {
+    t.plan(2)
+    const db = SqlDatabase.open('test.db', true)
+    const clockStore = new ClockStore(db)
+
+    const repoId = 'repoId' as RepoId
+    const docId = 'abc123' as DocId
+    const clock = { abc123: 1, def456: 0 }
+    clockStore.update(repoId, docId, clock)
+
+    const repoId2 = 'repoId2' as RepoId
+    const clock2 = { abc123: 1, def456: 1 }
+    clockStore.update(repoId2, docId, clock2)
+
+    const clock3 = { abc123: 2, def456: 0 }
+    clockStore.update(repoId, docId, clock3)
+
+    const res1 = clockStore.get(repoId, docId)
+    const res2 = clockStore.get(repoId2, docId)
+    t.deepEqual(res1, clock3)
+    t.deepEqual(res2, clock2)
+    db.close()
+  })
 })

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -9,13 +9,13 @@ test('Share a doc between two repos', (t) => {
   const repoB = testRepo()
 
   const clientA = new Client({
-    id: repoA.id,
+    id: repoA.swarmId,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.id,
+    id: repoB.swarmId,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
@@ -60,19 +60,19 @@ test("Three way docs don't load until all canges are in", (t) => {
   const repoC = testRepo()
 
   const clientA = new Client({
-    id: repoA.id,
+    id: repoA.swarmId,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.id,
+    id: repoB.swarmId,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientC = new Client({
-    id: repoC.id,
+    id: repoC.swarmId,
     stream: repoC.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
@@ -128,13 +128,13 @@ test('Message about a doc between two repos', (t) => {
   const repoB = testRepo()
 
   const clientA = new Client({
-    id: repoA.id,
+    id: repoA.swarmId,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.id,
+    id: repoB.swarmId,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -9,13 +9,13 @@ test('Share a doc between two repos', (t) => {
   const repoB = testRepo()
 
   const clientA = new Client({
-    id: repoA.swarmId,
+    id: repoA.swarmKey,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.swarmId,
+    id: repoB.swarmKey,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
@@ -60,19 +60,19 @@ test("Three way docs don't load until all canges are in", (t) => {
   const repoC = testRepo()
 
   const clientA = new Client({
-    id: repoA.swarmId,
+    id: repoA.swarmKey,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.swarmId,
+    id: repoB.swarmKey,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientC = new Client({
-    id: repoC.swarmId,
+    id: repoC.swarmKey,
     stream: repoC.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
@@ -128,13 +128,13 @@ test('Message about a doc between two repos', (t) => {
   const repoB = testRepo()
 
   const clientA = new Client({
-    id: repoA.swarmId,
+    id: repoA.swarmKey,
     stream: repoA.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })
 
   const clientB = new Client({
-    id: repoB.swarmId,
+    id: repoB.swarmKey,
     stream: repoB.stream,
     url: 'wss://discovery-cloud.herokuapp.com',
   })

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -181,7 +181,7 @@ test('Changing a document updates the clock store', async (t) => {
   // Note: the interface of repo.change doesn't guarantee this
   // won't race - but it doesn't. We should change this test such
   // that a race can't be introduced.
-  t.deepEqual(expectedClock, repo.back.clocks.get(docId))
+  t.deepEqual(expectedClock, repo.back.clocks.get(repo.id, docId))
   // Clock is stored in ClockStore and matches expected value
   // NOTE: this will fire twice because we have a bug which
   // applies change twice.


### PR DESCRIPTION
Update ClockStore to use RepoId. There's some strangeness with exposing the repo id as a buffer to be used by discover-swarm/discovery-cloud. I believe we'll be changing those requirements, so for now we expose a `swarmId`. I expect to remove `swarmId` in a followup patch.

*NOTE:* This patch doesn't migrate the sql schema, it assumes we start from scratch. This assumes we haven't updated any downstream apps to use the latest hypermerge since the original ClockStore was introduced (pushpin master is yarn locked to a version of hypermerge before SqlDatabase/ClockStore).

Happy to introduce a migration if anyone thinks it's important or useful.