### PR TITLE
Enforce minimum block-size for hyperfiles

### DIFF
--- a/src/FileStore.ts
+++ b/src/FileStore.ts
@@ -5,9 +5,9 @@ import { validateFileURL } from './Metadata'
 import * as Keys from './Keys'
 import * as JsonBuffer from './JsonBuffer'
 import Queue from './Queue'
-import { MaxChunkSizeTransform, HashPassThrough } from './StreamLogic'
+import { ChunkSizeTransform, HashPassThrough } from './StreamLogic'
 
-export const MAX_BLOCK_SIZE = 62 * 1024
+export const BLOCK_SIZE = 62 * 1024
 
 export interface Header {
   url: HyperfileUrl
@@ -42,7 +42,7 @@ export default class FileStore {
     const appendStream = await this.feeds.appendStream(feedId)
 
     return new Promise<Header>((res, rej) => {
-      const chunkStream = new MaxChunkSizeTransform(MAX_BLOCK_SIZE)
+      const chunkStream = new ChunkSizeTransform(BLOCK_SIZE)
       const hashStream = new HashPassThrough('sha256')
 
       stream

--- a/tests/FileStore.test.ts
+++ b/tests/FileStore.test.ts
@@ -34,4 +34,38 @@ test('FileStore', (t) => {
 
     t.deepEqual(outputBuffer, testBuffer, 'reads the written buffer')
   })
+
+  t.test('writing and reading stream of small chunks', async (t) => {
+    t.plan(2)
+
+    const testBuffers = [
+      Buffer.alloc(30 * 1024, 1),
+      Buffer.alloc(30 * 1024, 2),
+      Buffer.alloc(30 * 1024, 3),
+      Buffer.alloc(30 * 1024, 4),
+      Buffer.alloc(30 * 1024, 5),
+    ]
+
+    const testBuffer = Buffer.concat(testBuffers)
+    const testStream = Stream.fromBuffers(testBuffers)
+    const header = await files.write(testStream, 'application/octet-stream')
+    const sha256 = createHash('sha256')
+      .update(testBuffer)
+      .digest('hex')
+
+    const expectedHeader: Header = {
+      size: testBuffer.length,
+      mimeType: 'application/octet-stream',
+      sha256,
+      blocks: 3,
+      url: header.url,
+    }
+
+    t.deepEqual(header, expectedHeader, 'reads the expected header')
+
+    const output = await files.read(header.url)
+    const outputBuffer = await Stream.toBuffer(output)
+
+    t.deepEqual(outputBuffer, testBuffer, 'reads the written buffer')
+  })
 })

--- a/tests/StreamLogic.test.ts
+++ b/tests/StreamLogic.test.ts
@@ -3,38 +3,69 @@ import * as Stream from '../src/StreamLogic'
 import { expect } from './misc'
 
 test('StreamLogic', (t) => {
+  t.test('fromBuffers', (t) => {
+    Stream.fromBuffers([Buffer.alloc(10, 1), Buffer.alloc(10, 2), Buffer.alloc(10, 3)]).on(
+      'data',
+      expect(t, (x) => x, [
+        [Buffer.alloc(10, 1), 'first chunk is 10 bytes'],
+        [Buffer.alloc(10, 2), 'second chunk is 10 bytes'],
+        [Buffer.alloc(10, 3), 'third chunk is 10 bytes'],
+      ])
+    )
+  })
+
   t.test('ChunkSizeTransform', (t) => {
+    t.test('stream with exact-sized chunks', (t) => {
+      Stream.fromBuffers([Buffer.alloc(10, 1), Buffer.alloc(10, 2), Buffer.alloc(10, 3)])
+        .pipe(new Stream.ChunkSizeTransform(10))
+        .on(
+          'data',
+          expect(t, (x) => x, [
+            [Buffer.alloc(10, 1), 'first chunk is 10 bytes'],
+            [Buffer.alloc(10, 2), 'second chunk is 10 bytes'],
+            [Buffer.alloc(10, 3), 'third chunk is 10 bytes'],
+          ])
+        )
+    })
+
     t.test('stream with one small chunk', (t) => {
       Stream.fromBuffer(Buffer.alloc(5, 1))
-        .pipe(new Stream.MaxChunkSizeTransform(10))
+        .pipe(new Stream.ChunkSizeTransform(10))
         .on('data', expect(t, (x) => x, [[Buffer.alloc(5, 1), 'only chunk is 5 bytes']]))
     })
 
     t.test('stream with small last chunk', (t) => {
+      t.plan(2)
+
+      const transform = new Stream.ChunkSizeTransform(10)
       Stream.fromBuffer(Buffer.alloc(39, 1))
-        .pipe(new Stream.MaxChunkSizeTransform(10))
+        .pipe(transform)
         .on(
           'data',
           expect(t, (x) => x, [
             [Buffer.alloc(10, 1), 'first chunk is 10 bytes'],
             [Buffer.alloc(10, 1), 'second chunk is 10 bytes'],
             [Buffer.alloc(10, 1), 'third chunk is 10 bytes'],
-            [Buffer.alloc(9, 1), 'fourth chunk is 9 bytes'],
+            [
+              Buffer.alloc(9, 1),
+              'fourth chunk is 9 bytes',
+              () => {
+                t.equal(transform.processedBytes, 39, 'processedBytes is correct')
+                t.equal(transform.chunkCount, 4, 'chunkCount is correct')
+              },
+            ],
           ])
         )
     })
 
     t.test('input stream has smaller chunks', (t) => {
-      Stream.fromBuffer(Buffer.alloc(39, 1))
-        .pipe(new Stream.MaxChunkSizeTransform(10))
-        .pipe(new Stream.MaxChunkSizeTransform(20))
+      Stream.fromBuffers([Buffer.alloc(10, 1), Buffer.alloc(10, 2), Buffer.alloc(9, 3)])
+        .pipe(new Stream.ChunkSizeTransform(20))
         .on(
           'data',
           expect(t, (x) => x, [
-            [Buffer.alloc(10, 1), 'first chunk is 10 bytes'],
-            [Buffer.alloc(10, 1), 'second chunk is 10 bytes'],
-            [Buffer.alloc(10, 1), 'third chunk is 10 bytes'],
-            [Buffer.alloc(9, 1), 'fourth chunk is 9 bytes'],
+            [Buffer.concat([Buffer.alloc(10, 1), Buffer.alloc(10, 2)]), 'first chunk is 20 bytes'],
+            [Buffer.alloc(9, 3), 'second chunk is 9 bytes'],
           ])
         )
     })


### PR DESCRIPTION
Renamed `MaxChunkSizeTransform` to `ChunkSizeTransform`. `ChunkSizeTransform` now handles chunks that are too big or too small.

The result being that all hyperfile blocks in a feed (except the last block) are exactly 62k.