### PR TITLE
Network fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "@types/ws": "^6.0.3",
     "husky": "^3.0.5",
     "hyperswarm": "^2.3.1",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "tape": "^4.11.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.6.2",
+    "typescript": "^3.7.2",
     "uuid": "^3.3.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/uuid": "^3.4.5",
     "@types/ws": "^6.0.3",
     "husky": "^3.0.5",
-    "hyperswarm": "^2.1.0",
+    "hyperswarm": "^2.3.1",
     "prettier": "^1.18.2",
     "tape": "^4.11.0",
     "ts-node": "^8.3.0",

--- a/src/DocFrontend.ts
+++ b/src/DocFrontend.ts
@@ -11,7 +11,7 @@ import { ActorId, DocId, DocUrl, toDocUrl } from './Misc'
 
 const log = Debug('hypermerge:front')
 
-export type Patch = Patch
+export { Patch }
 
 type Mode = 'pending' | 'read' | 'write'
 

--- a/src/FeedStore.ts
+++ b/src/FeedStore.ts
@@ -1,12 +1,12 @@
 import { Readable, Writable } from 'stream'
-import hypercore, { Feed } from 'hypercore'
+import hypercore, { Feed as HypercoreFeed } from 'hypercore'
 import { KeyPair, decodePair, PublicId, DiscoveryId } from './Keys'
 import { getOrCreate, toDiscoveryId, createMultiPromise } from './Misc'
 import Queue from './Queue'
 import { Database, Statement } from './SqlDatabase'
 import * as Crypto from './Crypto'
 
-export type Feed = Feed<Block>
+export type Feed = HypercoreFeed<Block>
 export type FeedId = PublicId
 export type Block = Uint8Array
 
@@ -26,7 +26,7 @@ interface StorageFn {
 
 export default class FeedStore {
   private storage: (discoveryId: DiscoveryId) => (filename: string) => unknown
-  private loaded: Map<PublicId, Feed<Block>> = new Map()
+  private loaded: Map<PublicId, Feed> = new Map()
   info: FeedInfoStore
 
   constructor(db: Database, storageFn: StorageFn) {
@@ -119,7 +119,7 @@ export default class FeedStore {
     await Promise.all([...this.loaded.keys()].map((feedId) => this.closeFeed(feedId)))
   }
 
-  async getFeed(feedId: FeedId): Promise<Feed<Block>> {
+  async getFeed(feedId: FeedId): Promise<Feed> {
     return this.open(feedId)
   }
 
@@ -127,7 +127,7 @@ export default class FeedStore {
     return await this.openOrCreateFeed({ publicKey: publicId })
   }
 
-  private openOrCreateFeed(keys: KeyPair): Promise<Feed<Block>> {
+  private openOrCreateFeed(keys: KeyPair): Promise<Feed> {
     return new Promise((res, _rej) => {
       const publicId = keys.publicKey as FeedId
 

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -98,7 +98,7 @@ export default class Network {
       isClient: details.client,
       type: details.type,
       onClose() {
-        if (!conn.isConfirmed) details.ban()
+        if (!conn.isConfirmed) details.ban?.()
       },
     })
 

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -94,7 +94,8 @@ export default class Network {
   }
 
   private onConnection = async (socket: Socket, details: ConnectionDetails) => {
-    details.reconnect(false)
+    // NOTE(jeff): Disabling this for now, the `details.ban()` should already better handle this:
+    // details.reconnect(false)
 
     const conn = new PeerConnection(socket, {
       isClient: details.client,

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -94,9 +94,6 @@ export default class Network {
   }
 
   private onConnection = async (socket: Socket, details: ConnectionDetails) => {
-    // NOTE(jeff): Disabling this for now, the `details.ban()` should already better handle this:
-    // details.reconnect(false)
-
     const conn = new PeerConnection(socket, {
       isClient: details.client,
       type: details.type,

--- a/src/NetworkPeer.ts
+++ b/src/NetworkPeer.ts
@@ -49,6 +49,8 @@ export default class NetworkPeer {
    * add hold onto it and wait for a ConfirmConnection message.
    */
   addConnection(conn: PeerConnection): void {
+    this.pendingConnections.add(conn)
+
     if (this.isConnected) {
       this.closeConnection(conn)
       return
@@ -59,8 +61,6 @@ export default class NetworkPeer {
       this.confirmConnection(conn)
       return
     }
-
-    this.pendingConnections.add(conn)
 
     conn.networkBus.subscribe((msg) => {
       if (msg.type === 'ConfirmConnection') {
@@ -78,12 +78,11 @@ export default class NetworkPeer {
       this.closeConnection(pendingConn)
     }
 
-    this.pendingConnections.clear()
-
     this.connectionQ.push(conn)
   }
 
   closeConnection(conn: PeerConnection): void {
+    this.pendingConnections.delete(conn)
     conn.close()
     this.closedConnectionCount += 1
   }

--- a/src/PeerConnection.ts
+++ b/src/PeerConnection.ts
@@ -9,7 +9,7 @@ import { PrefixMatchPassThrough, InvalidPrefixError } from './StreamLogic'
 const VERSION_PREFIX = Buffer.from('hypermerge.v1')
 
 export interface SocketInfo {
-  type: 'tcp' | 'utp'
+  type: 'tcp' | 'utp' | 'cloud'
   isClient: boolean
   onClose?(): void
 }

--- a/src/SwarmInterface.ts
+++ b/src/SwarmInterface.ts
@@ -1,10 +1,9 @@
 import { Socket } from 'net'
-import { EventEmitter } from 'events'
 
 export { Socket }
 export type SocketType = 'tcp' | 'utp' | 'cloud'
 
-export interface Swarm extends EventEmitter {
+export interface Swarm {
   join(dk: Buffer, options?: JoinOptions): void
   leave(dk: Buffer): void
   on<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this

--- a/src/SwarmInterface.ts
+++ b/src/SwarmInterface.ts
@@ -1,22 +1,20 @@
 import { Socket } from 'net'
+import { EventEmitter } from 'events'
 
 export { Socket }
-export type SocketType = 'tcp' | 'utp'
+export type SocketType = 'tcp' | 'utp' | 'cloud'
 
-export interface Swarm {
+export interface Swarm extends EventEmitter {
   join(dk: Buffer, options?: JoinOptions): void
   leave(dk: Buffer): void
   on<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this
   off<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this
-  removeAllListeners(): void
   destroy(cb: () => void): void
 }
 
 export interface SwarmEvents {
   connection(socket: Socket, details: ConnectionDetails): void
-  disconnection(socket: Socket, details: ConnectionDetails): void
   peer(peer: PeerInfo): void
-  updated(info: { key: Buffer }): void
   listening(): void
 }
 
@@ -27,8 +25,8 @@ export interface JoinOptions {
 
 export interface BaseConnectionDetails {
   type: SocketType
-  reconnect(shouldReconnect: boolean): void
-  ban(): void
+  reconnect?(shouldReconnect: boolean): void
+  ban?(): void
 }
 
 export interface InitiatedConnectionDetails extends BaseConnectionDetails {

--- a/src/SwarmInterface.ts
+++ b/src/SwarmInterface.ts
@@ -17,6 +17,7 @@ export interface SwarmEvents {
   disconnection(socket: Socket, details: ConnectionDetails): void
   peer(peer: PeerInfo): void
   updated(info: { key: Buffer }): void
+  listening(): void
 }
 
 export interface JoinOptions {

--- a/src/types/hyperswarm.d.ts
+++ b/src/types/hyperswarm.d.ts
@@ -1,1 +1,123 @@
-declare module 'hyperswarm'
+declare module 'hyperswarm' {
+  import { Socket } from 'net'
+
+  export { Socket }
+  export type SocketType = 'tcp' | 'utp'
+
+  export interface Options {
+    /** Optionally overwrite the default set of bootstrap servers */
+    bootstrap?: string[]
+
+    /**
+     * Set to false if this is a long running instance on a server
+     * When running in ephemeral mode (default) you don't join the
+     * DHT but just query it instead.
+     * Default: true
+     */
+    ephemeral?: boolean
+
+    /** Total amount of peers that this peer will connect to. Default: 24 */
+    maxPeers?: number
+
+    /**
+     * set to a number to restrict the amount of server socket based peer connections,
+     * unrestricted by default. Setting to 0 is the same as Infinity, to disallow server
+     * connections set to -1.
+     * Default: Infinity
+     */
+    maxServerSockets?: number
+
+    /**
+     * set to a number to restrict the amount of client sockets based peer connections,
+     * unrestricted by default.
+     * Default: Infinity
+     */
+    maxClientSockets?: number
+
+    /** configure peer management behaviour */
+    queue?: {
+      /**
+       * an array of backoff times, in millieconds every time a failing peer connection is retried
+       * it will wait for specified milliseconds based on the retry count, until it reaches the end
+       * of the requeue array at which time the peer is considered unresponsive and retry attempts
+       * cease.
+       */
+      requeue?: number[]
+
+      /**
+       * configure when to forget certain peer characteristics and treat them as fresh
+       * peer connections again.
+       */
+      forget?: {
+        /** how long to wait before forgetting that a peer has become unresponsive. Default: 7500 */
+        unresponsive?: number
+
+        /** how long to wait before fogetting that a peer has been banned. Default: Infinity */
+        banned?: number
+
+        /**
+         * attempt to reuse existing connections between peers across multiple topics.
+         * Default: false
+         */
+        multiplex?: boolean
+      }
+    }
+  }
+
+  export default class Hyperswarm {
+    constructor(options?: Options)
+
+    join(dk: Buffer, options?: JoinOptions): void
+    leave(dk: Buffer): void
+    on<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this
+    off<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this
+    removeAllListeners(): void
+    destroy(cb: () => void): void
+  }
+
+  export interface SwarmEvents {
+    connection(socket: Socket, details: ConnectionDetails): void
+    disconnection(socket: Socket, details: ConnectionDetails): void
+    peer(peer: PeerInfo): void
+    updated(info: { key: Buffer }): void
+    listening(): void
+  }
+
+  export interface JoinOptions {
+    announce?: boolean
+    lookup?: boolean
+  }
+
+  export interface BaseConnectionDetails {
+    type: SocketType
+    reconnect(shouldReconnect: boolean): void
+    ban(): void
+  }
+
+  export interface InitiatedConnectionDetails extends BaseConnectionDetails {
+    // Connection initiated by this node
+    client: true
+    peer: PeerInfo
+  }
+
+  export interface ReceivedConnectionDetails extends BaseConnectionDetails {
+    // Connection not initiated by this node
+    client: false
+    peer: null
+  }
+
+  export type ConnectionDetails = InitiatedConnectionDetails | ReceivedConnectionDetails
+
+  export interface PeerInfo {
+    port: number
+    host: string // IP of peer
+    local: boolean // Is the peer on the LAN?
+    topic?: Buffer // The identifier which this peer was discovered under.
+    referrer: null | {
+      // Info about the node that informed us of the peer.
+      port: number
+      host: string // IP of referrer
+      id: Buffer
+    }
+  }
+}

--- a/src/types/hyperswarm.d.ts
+++ b/src/types/hyperswarm.d.ts
@@ -1,8 +1,11 @@
 declare module 'hyperswarm' {
+  import { EventEmitter } from 'events'
   import { Socket } from 'net'
 
   export { Socket }
   export type SocketType = 'tcp' | 'utp'
+
+  export default (options?: Options) => Hyperswarm
 
   export interface Options {
     /** Optionally overwrite the default set of bootstrap servers */
@@ -45,6 +48,12 @@ declare module 'hyperswarm' {
       requeue?: number[]
 
       /**
+       * attempt to reuse existing connections between peers across multiple topics.
+       * Default: false
+       */
+      multiplex?: boolean
+
+      /**
        * configure when to forget certain peer characteristics and treat them as fresh
        * peer connections again.
        */
@@ -54,19 +63,11 @@ declare module 'hyperswarm' {
 
         /** how long to wait before fogetting that a peer has been banned. Default: Infinity */
         banned?: number
-
-        /**
-         * attempt to reuse existing connections between peers across multiple topics.
-         * Default: false
-         */
-        multiplex?: boolean
       }
     }
   }
 
-  export default class Hyperswarm {
-    constructor(options?: Options)
-
+  export interface Hyperswarm extends EventEmitter {
     join(dk: Buffer, options?: JoinOptions): void
     leave(dk: Buffer): void
     on<K extends keyof SwarmEvents>(name: K, cb: SwarmEvents[K]): this

--- a/tests/Network.test.ts
+++ b/tests/Network.test.ts
@@ -8,7 +8,7 @@ interface TestMsg {
 }
 
 test('Network', (t) => {
-  t.plan(3)
+  t.plan(5)
 
   const topic = testDiscoveryId()
 
@@ -20,6 +20,7 @@ test('Network', (t) => {
 
   netA.peerQ.subscribe((peer) => {
     t.isEqual(peer.id, netB.selfId, 'netA finds netB')
+    t.assert(netA.discovered.size === 1, 'netA records a discovery')
 
     const bus = new MessageBus<TestMsg>(peer.connection.openChannel('TestMsg'))
 
@@ -30,6 +31,8 @@ test('Network', (t) => {
 
   netB.peerQ.subscribe((peer) => {
     t.isEqual(peer.id, netA.selfId, 'netB finds netA')
+    t.assert(netB.discovered.size === 1, 'netB records a discovery')
+
     const bus = new MessageBus<TestMsg>(peer.connection.openChannel('TestMsg'))
     bus.send({ senderId: netB.selfId })
   })

--- a/tests/misc.ts
+++ b/tests/misc.ts
@@ -32,7 +32,11 @@ export function testDb(): SqlDatabase.Database {
 }
 
 export function testSwarm() {
-  return Hyperswarm()
+  return Hyperswarm({
+    queue: {
+      multiplex: true,
+    },
+  })
 }
 
 export function testDiscoveryId(): DiscoveryId {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,10 +1238,10 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-hash@^1.0.1:
   version "1.0.1"
@@ -1795,10 +1795,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uint64be@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,10 +32,18 @@
     record-cache "^1.1.0"
     sodium-universal "^2.0.0"
 
-"@hyperswarm/discovery@^1.1.0", "@hyperswarm/discovery@^1.2.0":
+"@hyperswarm/discovery@^1.1.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@hyperswarm/discovery/-/discovery-1.5.0.tgz#28b8ce04b777370d711a8959a77873bd71f978c1"
   integrity sha512-DrHrkBk70wn3CP+dnVCTtlrE4q/fW2wBcigjaUoH0YSVvaU4YCw1EHDXGDqjOXWifvvXzjvSe5YHnuhYqnjq6A==
+  dependencies:
+    "@hyperswarm/dht" "^3.0.0"
+    multicast-dns "^7.2.0"
+
+"@hyperswarm/discovery@^1.6.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@hyperswarm/discovery/-/discovery-1.7.0.tgz#72492f040a7b1caa1e212070229755b972b92bc0"
+  integrity sha512-eXMOh+Sb7P+SdfoZxLOeRiy5SlJHOODLrfQIePfrV+mUp6LRfaG07R9osjeXq2tA7LEKATJK9TXFB56erYA1zw==
   dependencies:
     "@hyperswarm/dht" "^3.0.0"
     multicast-dns "^7.2.0"
@@ -47,12 +55,12 @@
   dependencies:
     sodium-universal "^2.0.0"
 
-"@hyperswarm/network@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@hyperswarm/network/-/network-1.0.0.tgz#e5c92fac339f3866bb9f8cc1fc78ec5eb8fceb3a"
-  integrity sha512-mWoUbg35uPKDVbtXKr5+OcK/mrsNRWPPrYfOXvSBUeWMh6+Kcbw8PMOYdKPFYiVw/MKh+gOYI4zkD+IpcW6cFA==
+"@hyperswarm/network@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@hyperswarm/network/-/network-1.1.2.tgz#dfcb7ef7f3392bbf667ebeef130ea4c451d98e97"
+  integrity sha512-LMb29j0Hn/1tOr+u+HhgHaKAkbxeb2WRPSrJ3ZhdbxbkKLb+O9b+ewKpFMBDczk79gb0GwgfSkxhFDb5w0Hp0Q==
   dependencies:
-    "@hyperswarm/discovery" "^1.2.0"
+    "@hyperswarm/discovery" "^1.6.0"
     nanoresource "^1.0.0"
     utp-native "^2.1.3"
 
@@ -758,13 +766,13 @@ hypercore@^8.2.5:
   optionalDependencies:
     fd-lock "^1.0.2"
 
-hyperswarm@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/hyperswarm/-/hyperswarm-2.1.0.tgz#f277036d5e4bf683eb589b9902885d00c529aa1a"
-  integrity sha512-wLglMq3vNlgxEXrtf1nMhKoVwDjgHjuU/6mFqmezBoCltqiltFGVE59DbRpFD2O/4dvFop4vli8dBPN/tsPRvg==
+hyperswarm@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hyperswarm/-/hyperswarm-2.3.1.tgz#dcf1bc75a4b178d0f6eadec233a4606a0b341c1c"
+  integrity sha512-lseDBart+1nx7MCBm9NA8FJTbxTe7qlvwEOYp2t1tuchXh7b+zlu3Pu8t6qlH4YUtYdRBhl64FiLiSr1657/Dw==
   dependencies:
     "@hyperswarm/discovery" "^1.1.0"
-    "@hyperswarm/network" "1.0.0"
+    "@hyperswarm/network" "^1.1.2"
     shuffled-priority-queue "^2.1.0"
     utp-native "^2.1.3"
 


### PR DESCRIPTION
* Ensures that we don't `swarm.join` until we've confirmed that it's listening.
* Records discovered peers prior to connection. Useful for debugging.
* Disables swarm `.reconnect(false)`
* Improves hyperswarm types
* Typescript 3.7 and bumps prettier