### PR TITLE
Pass crypto errors to the client

### DIFF
--- a/src/CryptoClient.ts
+++ b/src/CryptoClient.ts
@@ -24,7 +24,7 @@ export default class CryptoClient {
       const docId = validateDocURL(url)
       this.request({ type: 'SignMsg', docId, message }, (msg: SignReplyMsg) => {
         if (msg.success) return res(msg.signature)
-        rej()
+        rej(msg.error)
       })
     })
   }
@@ -48,7 +48,7 @@ export default class CryptoClient {
         { type: 'BoxMsg', senderSecretKey, recipientPublicKey, message },
         (msg: BoxReplyMsg) => {
           if (msg.success) return res([msg.box, msg.nonce])
-          rej()
+          rej(msg.error)
         }
       )
     })
@@ -65,7 +65,7 @@ export default class CryptoClient {
         { type: 'OpenBoxMsg', senderPublicKey, recipientSecretKey, box, nonce },
         (msg: OpenBoxReplyMsg) => {
           if (msg.success) return res(msg.message)
-          rej()
+          rej(msg.error)
         }
       )
     })
@@ -78,7 +78,7 @@ export default class CryptoClient {
     return new Promise((res, rej) => {
       this.request({ type: 'SealedBoxMsg', publicKey, message }, (msg: SealedBoxReplyMsg) => {
         if (msg.success) return res(msg.sealedBox)
-        rej()
+        rej(msg.error)
       })
     })
   }
@@ -92,7 +92,7 @@ export default class CryptoClient {
         { type: 'OpenSealedBoxMsg', keyPair, sealedBox },
         (msg: OpenSealedBoxReplyMsg) => {
           if (msg.success) return res(msg.message)
-          rej()
+          rej(msg.error)
         }
       )
     })
@@ -102,7 +102,7 @@ export default class CryptoClient {
     return new Promise((res, rej) => {
       this.request({ type: 'EncryptionKeyPairMsg' }, (msg: EncryptionKeyPairReplyMsg) => {
         if (msg.success) return res(msg.keyPair)
-        rej()
+        rej(msg.error)
       })
     })
   }

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -147,3 +147,7 @@ function toWindowsNamedPipe(path: string): string {
   const sanitizedPath = path.replace(/^\//, '').replace(/\//g, '-')
   return `\\\\.\\pipe\\${sanitizedPath}`
 }
+
+export function errorMessage(e: Error) {
+  return `${e.name}: ${e.message}`
+}

--- a/src/RepoBackend.ts
+++ b/src/RepoBackend.ts
@@ -28,6 +28,7 @@ import {
   rootActorId,
   encodeActorId,
   toDiscoveryId,
+  errorMessage,
 } from './Misc'
 import Debug from 'debug'
 import * as Keys from './Keys'
@@ -567,8 +568,8 @@ export class RepoBackend {
             Buffer.from(query.message)
           )
           payload = { type: 'BoxReplyMsg', success: true, box, nonce }
-        } catch {
-          payload = { type: 'BoxReplyMsg', success: false }
+        } catch (e) {
+          payload = { type: 'BoxReplyMsg', success: false, error: errorMessage(e) }
         }
         this.toFrontend.push({ type: 'Reply', id, payload })
         break
@@ -583,8 +584,8 @@ export class RepoBackend {
             query.nonce
           )
           payload = { type: 'OpenBoxReplyMsg', success: true, message: message.toString() }
-        } catch {
-          payload = { type: 'OpenBoxReplyMsg', success: false }
+        } catch (e) {
+          payload = { type: 'OpenBoxReplyMsg', success: false, error: errorMessage(e) }
         }
         this.toFrontend.push({ type: 'Reply', id, payload })
         break
@@ -594,8 +595,8 @@ export class RepoBackend {
         try {
           const sealedBox = Crypto.sealedBox(query.publicKey, Buffer.from(query.message))
           payload = { type: 'SealedBoxReplyMsg', success: true, sealedBox }
-        } catch {
-          payload = { type: 'SealedBoxReplyMsg', success: false }
+        } catch (e) {
+          payload = { type: 'SealedBoxReplyMsg', success: false, error: errorMessage(e) }
         }
         this.toFrontend.push({ type: 'Reply', id, payload })
         break
@@ -605,8 +606,8 @@ export class RepoBackend {
         try {
           const message = Crypto.openSealedBox(query.keyPair, query.sealedBox)
           payload = { type: 'OpenSealedBoxReplyMsg', success: true, message: message.toString() }
-        } catch {
-          payload = { type: 'OpenSealedBoxReplyMsg', success: false }
+        } catch (e) {
+          payload = { type: 'OpenSealedBoxReplyMsg', success: false, error: errorMessage(e) }
         }
         this.toFrontend.push({ type: 'Reply', id, payload })
         break
@@ -620,8 +621,8 @@ export class RepoBackend {
             success: true,
             signature: signature,
           }
-        } catch {
-          payload = { type: 'SignReplyMsg', success: false }
+        } catch (e) {
+          payload = { type: 'SignReplyMsg', success: false, error: errorMessage(e) }
         }
         this.toFrontend.push({
           type: 'Reply',
@@ -634,7 +635,7 @@ export class RepoBackend {
         let success
         try {
           success = this.feeds.verify(query.docId, Buffer.from(query.message), query.signature)
-        } catch {
+        } catch (e) {
           success = false
         }
         this.toFrontend.push({

--- a/src/RepoMsg.ts
+++ b/src/RepoMsg.ts
@@ -81,6 +81,7 @@ export interface SealedBoxSuccessReplyMsg {
 export interface SealedBoxErrorReplyMsg {
   type: 'SealedBoxReplyMsg'
   success: false
+  error: string
 }
 
 export interface OpenSealedBoxMsg {
@@ -100,6 +101,7 @@ export interface OpenSealedBoxSuccessMsg {
 export interface OpenSealedBoxErrorMsg {
   type: 'OpenSealedBoxReplyMsg'
   success: false
+  error: string
 }
 
 export interface BoxMsg {
@@ -121,6 +123,7 @@ export interface BoxSuccessReplyMsg {
 export interface BoxErrorReplyMsg {
   type: 'BoxReplyMsg'
   success: false
+  error: string
 }
 
 export interface OpenBoxMsg {
@@ -142,6 +145,7 @@ export interface OpenBoxSuccessReplyMsg {
 export interface OpenBoxErrorReplyMsg {
   type: 'OpenBoxReplyMsg'
   success: false
+  error: string
 }
 
 export interface EncryptionKeyPairMsg {
@@ -161,6 +165,7 @@ export interface EncryptionKeyPairSuccessReplyMsg {
 export interface EncryptionKeyPairErrorReplyMsg {
   type: 'EncryptionKeyPairReplyMsg'
   success: false
+  error: string
 }
 
 export interface SignMsg {
@@ -180,6 +185,7 @@ export interface SignSuccessReplyMsg {
 export interface SignErrorReplyMsg {
   type: 'SignReplyMsg'
   success: false
+  error: string
 }
 
 export interface VerifyMsg {


### PR DESCRIPTION
This could use some cleaning up (Request<Response> and a base Response maybe), but better than silently swallowing errors.